### PR TITLE
Single syscall isr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ KERNEL_OBJS :=  \
 	loader.o \
 	com.o \
 	acpi.o \
-	hpet.o
+	hpet.o \
+	syscall-asm.o
 
 TEST_PROGS := \
 	test-debug \

--- a/kernel/com.h
+++ b/kernel/com.h
@@ -2,9 +2,11 @@
 #define __SILVOS_COM_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 void com_initialize (void);
 void com_putch (char c);
 void com_debug (char *text);
+uint32_t com_debug_thread (char *text, uint32_t len);
 
 #endif

--- a/kernel/george.c
+++ b/kernel/george.c
@@ -47,17 +47,7 @@ void initialize_idt (void) {
   register_isr(0x28, rtc_isr, 0);
 
   /* Syscalls */
-  register_isr(0x36, yield_isr, 0);
-  register_isr(0x37, putch_isr, 0);
-  register_isr(0x38, exit_isr, 0);
-  register_isr(0x39, getch_isr, 0);
-  register_isr(0x3A, read_isr, 0);
-  register_isr(0x3B, write_isr, 0);
-  register_isr(0x3C, palloc_isr, 0);
-  register_isr(0x3D, pfree_isr, 0);
-  register_isr(0x3E, debug_isr, 0);
-  register_isr(0x3F, nanosleep_isr, 0);
-
+  register_isr(0x36, syscall_isr, 0);
 }
 
 typedef struct {

--- a/kernel/ide.h
+++ b/kernel/ide.h
@@ -13,4 +13,7 @@
 
 void ide_device_register(uint8_t bus, uint8_t device, uint8_t function);
 
+int read_sector (uint64_t sector, void *to);
+int write_sector (uint64_t sector, const void *from);
+
 #endif

--- a/kernel/isr-asm.s
+++ b/kernel/isr-asm.s
@@ -31,64 +31,13 @@
 
 /* Syscalls */
 
-.GLOBAL yield_isr
-yield_isr:
-        call schedule
-        iretq
-
-.GLOBAL putch_isr
-putch_isr:
-        mov %rax,%rdi
-        call putc
-        iretq
-
-.GLOBAL exit_isr
-exit_isr:
-        call thread_exit
-        call schedule
-
-.GLOBAL getch_isr
-getch_isr:
-        call getch
-        iretq
-
-.GLOBAL read_isr
-read_isr:
-	mov %rax,%rdi
-	mov %rbx,%rsi
-	call read_sector
-	iretq
-
-.GLOBAL write_isr
-write_isr:
-	mov %rax,%rdi
-	mov %rbx,%rsi
-	call write_sector
-	iretq
-
-.GLOBAL palloc_isr
-palloc_isr:
-	mov %rax,%rdi
-	call palloc
-	iretq
-
-.GLOBAL pfree_isr
-pfree_isr:
-	mov %rax,%rdi
-	call pfree
-	iretq
-
-.GLOBAL debug_isr
-debug_isr:
-	mov %rax,%rdi
-	mov %rbx,%rsi
-	call com_debug_thread
-	iretq
-
-.GLOBAL nanosleep_isr
-nanosleep_isr:
-	mov %rax,%rdi
-	call hpet_nanosleep
+.GLOBAL syscall_isr
+syscall_isr:
+	mov %rbx,%rdi
+	mov %rcx,%rsi
+	mov $syscall_defns, %r8
+	mov (%r8, %rax, 8), %rax
+	call *%rax
 	iretq
 
 /* Interrupts */

--- a/kernel/isr-asm.s
+++ b/kernel/isr-asm.s
@@ -78,8 +78,7 @@ nm_isr:
 .GLOBAL fault_isr
 fault_isr:
 	push_caller_save_reg
-        call thread_exit
-        call schedule
+        call thread_exit_schedule
 
 .GLOBAL df_isr
 df_isr:

--- a/kernel/isr.h
+++ b/kernel/isr.h
@@ -1,16 +1,7 @@
 #ifndef __SILVOS_ISR_H
 #define __SILVOS_ISR_H
 
-void yield_isr (void);
-void putch_isr (void);
-void exit_isr (void);
-void getch_isr (void);
-void read_isr (void);
-void write_isr (void);
-void palloc_isr (void);
-void pfree_isr (void);
-void debug_isr (void);
-void nanosleep_isr (void);
+void syscall_isr (void);
 
 void fault_isr (void);
 void nm_isr (void);

--- a/kernel/pagefault.c
+++ b/kernel/pagefault.c
@@ -24,8 +24,7 @@ void pagefault_handler (void) {
   if (is_copying) {
     longjmp(for_copying, -1);
   } else {
-    thread_exit();
-    schedule();
+    thread_exit_schedule();
   }
 }
 

--- a/kernel/pagefault.h
+++ b/kernel/pagefault.h
@@ -3,7 +3,7 @@
 
 #include <stddef.h>
 
-void pagefault_handler (void);
+void __attribute__ ((noreturn)) pagefault_handler (void);
 
 int copy_from_user(void *to, const void *from, size_t count);
 int copy_to_user(void *to, const void *from, size_t count);

--- a/kernel/syscall-asm.s
+++ b/kernel/syscall-asm.s
@@ -1,3 +1,4 @@
+.section .rodata
 .GLOBAL syscall_defns
 syscall_defns:
 	.quad schedule

--- a/kernel/syscall-asm.s
+++ b/kernel/syscall-asm.s
@@ -1,0 +1,12 @@
+.GLOBAL syscall_defns
+syscall_defns:
+	.quad schedule
+	.quad putc
+	.quad thread_exit_schedule
+	.quad getch
+	.quad read_sector
+	.quad write_sector
+	.quad palloc
+	.quad pfree
+	.quad com_debug_thread
+	.quad hpet_nanosleep

--- a/kernel/syscall-defs.h
+++ b/kernel/syscall-defs.h
@@ -1,0 +1,19 @@
+#ifndef __SILVOS_SYSCALL_DEFS_H
+#define __SILVOS_SYSCALL_DEFS_H
+
+typedef unsigned long long syscall_arg;
+
+#define SYSCALL_YIELD       0x00
+#define SYSCALL_PUTCH       0x01
+#define SYSCALL_EXIT        0x02
+#define SYSCALL_GETCH       0x03
+#define SYSCALL_READ        0x04
+#define SYSCALL_WRITE       0x05
+#define SYSCALL_PALLOC      0x06
+#define SYSCALL_PFREE       0x07
+#define SYSCALL_DEBUG       0x08
+#define SYSCALL_NANOSLEEP   0x09
+
+#define NUM_SYSCALLS        0x0A
+
+#endif

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -1,0 +1,11 @@
+#ifndef __SILVOS_SYSCALL_H
+#define __SILVOS_SYSCALL_H
+
+#include "syscall-defs.h"
+
+typedef syscall_arg (*syscall_func)(syscall_arg, syscall_arg);
+
+extern syscall_func syscall_defns[NUM_SYSCALLS];
+
+#endif
+

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -133,6 +133,11 @@ void thread_exit (void) {
   running_tcb->state = TS_NONEXIST;
 }
 
+void thread_exit_schedule (void) {
+  thread_exit();
+  schedule();
+}
+
 void block_current_thread (void) {
   running_tcb->state = TS_BLOCKED;
   schedule();

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -136,6 +136,7 @@ void thread_exit (void) {
 void thread_exit_schedule (void) {
   thread_exit();
   schedule();
+  panic("Rescheduled exited thread");
 }
 
 void block_current_thread (void) {

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -45,6 +45,7 @@ extern tcb *running_tcb;
 int user_thread_create (void *text, size_t length);
 void schedule_helper (void);
 void thread_exit (void);
+void thread_exit_schedule (void);
 void thread_start (void);
 void user_thread_start (void);
 void user_thread_launch (void);

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -45,7 +45,7 @@ extern tcb *running_tcb;
 int user_thread_create (void *text, size_t length);
 void schedule_helper (void);
 void thread_exit (void);
-void thread_exit_schedule (void);
+void __attribute__ ((noreturn)) thread_exit_schedule (void);
 void thread_start (void);
 void user_thread_start (void);
 void user_thread_launch (void);

--- a/userland/userland.h
+++ b/userland/userland.h
@@ -1,77 +1,71 @@
 #ifndef __SILVOS_USERLAND_H
 #define __SILVOS_USERLAND_H
 
-#define CALLER_SAVE_REGISTERS2 "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11"
-#define CALLER_SAVE_REGISTERS "rax", CALLER_SAVE_REGISTERS2
+/* Abstract Syscall Interface */
+
+#include "../kernel/syscall-defs.h"
+
+static inline syscall_arg __syscall(unsigned long syscallno, syscall_arg arg1, syscall_arg arg2) {
+  syscall_arg out;
+  __asm__ volatile("int $0x36"
+                   : "=a" (out)
+                   : "a" (syscallno), "b" (arg1), "c" (arg2)
+                   : "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11", "memory");
+  return out;
+}
+
+static inline syscall_arg __syscall0(unsigned long syscallno) {
+  return __syscall(syscallno, 0, 0);
+}
+
+static inline syscall_arg __syscall1(unsigned long syscallno, syscall_arg arg1) {
+  return __syscall(syscallno, arg1, 0);
+}
+
+static inline syscall_arg __syscall2(unsigned long syscallno, syscall_arg arg1, syscall_arg arg2) {
+  return __syscall(syscallno, arg1, arg2);
+}
+
+/* Actual Syscalls */
 
 static inline void yield (void) {
-  __asm__ volatile("int $0x36" ::: CALLER_SAVE_REGISTERS);
+  __syscall0(SYSCALL_YIELD);
 }
 
 static inline void putch (char c) {
-  __asm__ volatile("int $0x37" : "=a" (c) : "a" (c) : CALLER_SAVE_REGISTERS2);
+  __syscall1(SYSCALL_PUTCH, c);
 }
 
 static inline void exit (void) {
-  __asm__ volatile("int $0x38" ::: CALLER_SAVE_REGISTERS);
+  __syscall0(SYSCALL_EXIT);
 }
 
 static inline char getch (void) {
-  char c;
-  __asm__ volatile("int $0x39" : "=a" (c) :: CALLER_SAVE_REGISTERS2);
-  return c;
+  return (char)__syscall0(SYSCALL_GETCH);
 }
 
 static inline int read (long long sector, char dest[512]) {
-  int out;
-  __asm__ volatile("int $0x3A;"
-                   : "=a" (out)
-                   : "a" (sector), "b" (dest)
-                   : CALLER_SAVE_REGISTERS2, "memory");
-  return out;
+  return (int)__syscall2(SYSCALL_READ, sector, (syscall_arg)dest);
 }
 
 static inline int write (long long sector, const void *src) {
-  int out;
-  __asm__ volatile("int $0x3B;"
-                   : "=a" (out)
-                   : "a" (sector), "b" (src)
-                   : CALLER_SAVE_REGISTERS2, "memory");
-  return out;
+  return (int)__syscall2(SYSCALL_WRITE, sector, (syscall_arg)src);
 }
 
 static inline int palloc (const void *virt_addr) {
-  int out;
-  __asm__ volatile("int $0x3C;"
-                   : "=a" (out)
-                   : "a" (virt_addr)
-                   : CALLER_SAVE_REGISTERS2);
-  return out;
+  return (int)__syscall1(SYSCALL_PALLOC, (syscall_arg)virt_addr);
 }
 
 static inline int pfree (const void *virt_addr) {
-  int out;
-  __asm__ volatile("int $0x3D;"
-                   : "=a" (out)
-                   : "a" (virt_addr)
-                   : CALLER_SAVE_REGISTERS2);
-  return out;
+  return (int)__syscall1(SYSCALL_PFREE, (syscall_arg)virt_addr);
 }
 
 static inline int debug (const char *string, int len) {
-  int out;
-  __asm__ volatile("int $0x3E;"
-                   : "=a" (out)
-                   : "a" (string), "b" (len)
-                   : CALLER_SAVE_REGISTERS2, "memory");
-  return out;
+  return (int)__syscall2(SYSCALL_DEBUG, (syscall_arg)string, len);
 }
 
 static inline void nanosleep (long long usecs) {
-  __asm__ volatile("int $0x3F"
-                   : "=a" (usecs)
-                   : "a" (usecs)
-                   : CALLER_SAVE_REGISTERS2);
+  __syscall1(SYSCALL_NANOSLEEP, usecs);
 }
 
 #endif


### PR DESCRIPTION
This change creates an a more abstract API (with a single entrypoint) for userland to call syscalls, and fixes some of the collateral damage.

Some details are of note, and should be resolved before merging.

1. What should the convention be for including kernel headers in userland programs? Should stdint.h be imposed on all userland programs? If so the syscall_arg type is superfluous.

2. What should the convention be for the existence of pre-declarations in C header files for symbols defined in assembly? Strictly speaking, the three syscalls that had definitions added, and the entire existence of syscall.h (which is not referenced by anything) are unnecessary. Furthermore, many of the isr definitions in isr.h are wrongly typed.

3. Is it preferable to implement the syscall table in assembler or C? I had originally implemented it in C, but it involved quite a few unnecessary casts, and didn't seem to really add anything. Long-term it also might make more sense to switch the syscall table to use something like an X macro, and generate the numbers and jump table dynamically.