### PR TITLE
Add support for fork()

### DIFF
--- a/kernel/com.c
+++ b/kernel/com.c
@@ -22,6 +22,23 @@ void com_putch (char c) {
   outb(PORT, c);
 }
 
+void com_puts (const char *text) {
+  for (int i = 0; text[i]; ++i) {
+    com_putch(text[i]);
+  }
+}
+
+void com_put_tid (void) {
+  const char header[] = "THREAD 0x";
+  for (size_t i = 0; header[i]; i++) {
+    com_putch(header[i]);
+  }
+  const char hex[] = "0123456789ABCDEF";
+  uint8_t t = running_tcb->thread_id;
+  com_putch(hex[0x0F & (t >> 4)]);
+  com_putch(hex[0x0F & t]);
+}
+
 uint32_t com_debug_thread (char *text, uint32_t len) {
   /* TODO: check that user text is nice (doesn't contain control characters,
    * for intance) */
@@ -32,15 +49,7 @@ uint32_t com_debug_thread (char *text, uint32_t len) {
   if (copy_from_user(&tmp[0], text, len)) {
     return 0;
   }
-  const char header[] = "THREAD 0x";
-  for (size_t i = 0; header[i]; i++) {
-    com_putch(header[i]);
-  }
-  const char hex[] = "0123456789ABCDEF";
-  uint8_t t = running_tcb->thread_id;
-  com_putch(hex[0x0F & (t >> 4)]);
-  com_putch(hex[0x0F & t]);
-
+  com_put_tid();
   com_putch(':');
   com_putch(' ');
 

--- a/kernel/com.h
+++ b/kernel/com.h
@@ -6,7 +6,8 @@
 
 void com_initialize (void);
 void com_putch (char c);
-void com_debug (char *text);
+void com_puts (const char *text);
+void com_put_tid (void);
 uint32_t com_debug_thread (char *text, uint32_t len);
 
 #endif

--- a/kernel/isr-asm.s
+++ b/kernel/isr-asm.s
@@ -87,8 +87,8 @@ df_isr:
 
 .GLOBAL pf_isr
 pf_isr:
-        push_caller_save_reg
-	mov %cr2,%rax
-        call pagefault_handler
-        pop_caller_save_reg
-        iretq
+	push_caller_save_reg
+	mov %cr2,%rdi
+	call pagefault_handler
+	pop_caller_save_reg
+	iretq

--- a/kernel/memory-map.h
+++ b/kernel/memory-map.h
@@ -13,9 +13,8 @@ static inline uint64_t virt_to_phys(uint64_t addr) {
 
 /* Lower half of memory is for userland */
 
-#define LOC_USERZONE_BOT  0x000000000000
+#define LOC_USERZONE_BOT  0x000000001000
 
-#define LOC_TEXT          0x000000000000
 #define LOC_USER_STACK    0x7FFFFFFFF000
 #define LOC_USER_STACKTOP 0x7FFFFFFFFFF8
 

--- a/kernel/page-constants.h
+++ b/kernel/page-constants.h
@@ -79,4 +79,12 @@ static inline uint64_t PAGE_VIRT_PML4_OF(uint64_t mem) {
   return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
 }
 
+static inline uint64_t PAGE_PADDR_FROM_ENTRY(uint64_t entry) {
+  return PAGE_4K_ALIGN(entry) & ~PAGE_MASK_NX;
+}
+
+static inline uint64_t PAGE_FLAGS_FROM_ENTRY(uint64_t entry) {
+  return entry & (PAGE_MASK_NX | PAGE_4K_MASK);
+}
+
 #endif

--- a/kernel/page-constants.h
+++ b/kernel/page-constants.h
@@ -1,0 +1,82 @@
+#ifndef __SILVOS_PAGE_CONSTANTS_H
+#define __SILVOS_PAGE_CONSTANTS_H
+
+#include <stdint.h>
+
+static const uint64_t PAGE_MASK_PRESENT = 0x0000000000000001;
+static const uint64_t PAGE_MASK_WRITE   = 0x0000000000000002;
+static const uint64_t PAGE_MASK_PRIV    = 0x0000000000000004;
+static const uint64_t PAGE_MASK_WTCACHE = 0x0000000000000008; /* determines memory type */
+static const uint64_t PAGE_MASK_NOCACHE = 0x0000000000000010; /* determines memory type */
+static const uint64_t PAGE_MASK_ACCESS  = 0x0000000000000020; /* set by hardware */
+static const uint64_t PAGE_MASK_DIRTY   = 0x0000000000000040; /* set by hardware */
+static const uint64_t PAGE_MASK_SIZE    = 0x0000000000000080;
+static const uint64_t PAGE_MASK_GLOBAL  = 0x0000000000000100;
+static const uint64_t PAGE_MASK_PAT     = 0x0000000000001000; /* For 2M+ pages only */
+static const uint64_t PAGE_MASK_NX      = 0x8000000000000000;
+
+static const uint64_t PAGE_MASK__KERNEL = 0x0000000000000003; /* PAGE_MASK_PRESENT | PAGE_MASK_WRITE */
+static const uint64_t PAGE_MASK__USER   = 0x0000000000000007; /* PAGE_MASK_PRIV | PAGE_MASK__KERNEL */
+static const uint64_t PAGE_MASK__FAKE   = 0x0000000000000000;
+
+static const uint64_t PAGE_4K_MASK = (1L << 12) - 1;
+static const uint64_t PAGE_2M_MASK = (1L << 21) - 1;
+static const uint64_t PAGE_1G_MASK = (1L << 30) - 1;
+static const uint64_t PAGE_HT_MASK = (1L << 39) - 1;
+static const uint64_t PAGE_VM_MASK = (1L << 48) - 1;
+
+static const uint64_t PAGE_4K_SIZE = 1L << 12;
+static const uint64_t PAGE_2M_SIZE = 1L << 21;
+static const uint64_t PAGE_1G_SIZE = 1L << 30;
+static const uint64_t PAGE_HT_SIZE = 1L << 39;
+static const uint64_t PAGE_VM_SIZE = 1L << 48;
+
+static inline uint64_t PAGE_4K_OF(uint64_t mem) { return 0x1FF & (mem >> 12); }
+static inline uint64_t PAGE_2M_OF(uint64_t mem) { return 0x1FF & (mem >> 21); }
+static inline uint64_t PAGE_1G_OF(uint64_t mem) { return 0x1FF & (mem >> 30); }
+static inline uint64_t PAGE_HT_OF(uint64_t mem) { return 0x1FF & (mem >> 39); }
+
+static inline uint64_t PAGE_4K_ALIGN(uint64_t mem) { return mem & ~PAGE_4K_MASK; }
+static inline uint64_t PAGE_2M_ALIGN(uint64_t mem) { return mem & ~PAGE_2M_MASK; }
+static inline uint64_t PAGE_1G_ALIGN(uint64_t mem) { return mem & ~PAGE_1G_MASK; }
+static inline uint64_t PAGE_HT_ALIGN(uint64_t mem) { return mem & ~PAGE_HT_MASK; }
+
+static const uint64_t PAGE_PT_NUM_ENTRIES = 512;
+static const uint64_t PAGE_PT_SELF_MAP = 510;
+
+static inline uint64_t PAGE_MAKE_CANONICAL_ADDR(uint64_t mem) {
+  uint64_t lead = ((1L << 47) & mem) ? ~PAGE_VM_MASK : 0;
+  return lead | mem;
+}
+
+static inline uint64_t PAGE_VIRT_PT_OF(uint64_t mem) {
+  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_2M_MASK) >> 9;
+  uint64_t upper = (PAGE_PT_SELF_MAP << 39);
+  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
+}
+
+static inline uint64_t PAGE_VIRT_PD_OF(uint64_t mem) {
+  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_1G_MASK) >> 18;
+  uint64_t upper = (PAGE_PT_SELF_MAP << 39)
+                 | (PAGE_PT_SELF_MAP << 30);
+  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
+}
+
+static inline uint64_t PAGE_VIRT_PDPT_OF(uint64_t mem) {
+  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_HT_MASK) >> 27;
+  uint64_t upper = (PAGE_PT_SELF_MAP << 39)
+                 | (PAGE_PT_SELF_MAP << 30)
+                 | (PAGE_PT_SELF_MAP << 21);
+  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
+}
+
+static inline uint64_t PAGE_VIRT_PML4_OF(uint64_t mem) {
+  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_VM_MASK) >> 36;
+  uint64_t upper = (PAGE_PT_SELF_MAP << 39)
+                 | (PAGE_PT_SELF_MAP << 30)
+                 | (PAGE_PT_SELF_MAP << 21)
+                 | (PAGE_PT_SELF_MAP << 12);
+  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
+}
+
+#endif

--- a/kernel/page.h
+++ b/kernel/page.h
@@ -2,82 +2,7 @@
 #define __SILVOS_PAGE_H
 
 #include <stdint.h>
-
-static const uint64_t PAGE_MASK_PRESENT = 0x0000000000000001;
-static const uint64_t PAGE_MASK_WRITE   = 0x0000000000000002;
-static const uint64_t PAGE_MASK_PRIV    = 0x0000000000000004;
-static const uint64_t PAGE_MASK_WTCACHE = 0x0000000000000008; /* determines memory type */
-static const uint64_t PAGE_MASK_NOCACHE = 0x0000000000000010; /* determines memory type */
-static const uint64_t PAGE_MASK_ACCESS  = 0x0000000000000020; /* set by hardware */
-static const uint64_t PAGE_MASK_DIRTY   = 0x0000000000000040; /* set by hardware */
-static const uint64_t PAGE_MASK_SIZE    = 0x0000000000000080;
-static const uint64_t PAGE_MASK_GLOBAL  = 0x0000000000000100;
-static const uint64_t PAGE_MASK_PAT     = 0x0000000000001000; /* For 2M+ pages only */
-static const uint64_t PAGE_MASK_NX      = 0x8000000000000000;
-
-static const uint64_t PAGE_MASK__KERNEL = 0x0000000000000003; /* PAGE_MASK_PRESENT | PAGE_MASK_WRITE */
-static const uint64_t PAGE_MASK__USER   = 0x0000000000000007; /* PAGE_MASK_PRIV | PAGE_MASK__KERNEL */
-static const uint64_t PAGE_MASK__FAKE   = 0x0000000000000000;
-
-static const uint64_t PAGE_4K_MASK = (1L << 12) - 1;
-static const uint64_t PAGE_2M_MASK = (1L << 21) - 1;
-static const uint64_t PAGE_1G_MASK = (1L << 30) - 1;
-static const uint64_t PAGE_HT_MASK = (1L << 39) - 1;
-static const uint64_t PAGE_VM_MASK = (1L << 48) - 1;
-
-static const uint64_t PAGE_4K_SIZE = 1L << 12;
-static const uint64_t PAGE_2M_SIZE = 1L << 21;
-static const uint64_t PAGE_1G_SIZE = 1L << 30;
-static const uint64_t PAGE_HT_SIZE = 1L << 39;
-static const uint64_t PAGE_VM_SIZE = 1L << 48;
-
-static inline uint64_t PAGE_4K_OF(uint64_t mem) { return 0x1FF & (mem >> 12); }
-static inline uint64_t PAGE_2M_OF(uint64_t mem) { return 0x1FF & (mem >> 21); }
-static inline uint64_t PAGE_1G_OF(uint64_t mem) { return 0x1FF & (mem >> 30); }
-static inline uint64_t PAGE_HT_OF(uint64_t mem) { return 0x1FF & (mem >> 39); }
-
-static inline uint64_t PAGE_4K_ALIGN(uint64_t mem) { return mem & ~PAGE_4K_MASK; }
-static inline uint64_t PAGE_2M_ALIGN(uint64_t mem) { return mem & ~PAGE_2M_MASK; }
-static inline uint64_t PAGE_1G_ALIGN(uint64_t mem) { return mem & ~PAGE_1G_MASK; }
-static inline uint64_t PAGE_HT_ALIGN(uint64_t mem) { return mem & ~PAGE_HT_MASK; }
-
-static const uint64_t PAGE_PT_NUM_ENTRIES = 512;
-static const uint64_t PAGE_PT_SELF_MAP = 510;
-
-static inline uint64_t PAGE_MAKE_CANONICAL_ADDR(uint64_t mem) {
-  uint64_t lead = ((1L << 47) & mem) ? ~PAGE_VM_MASK : 0;
-  return lead | mem;
-}
-
-static inline uint64_t PAGE_VIRT_PT_OF(uint64_t mem) {
-  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_2M_MASK) >> 9;
-  uint64_t upper = (PAGE_PT_SELF_MAP << 39);
-  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
-}
-
-static inline uint64_t PAGE_VIRT_PD_OF(uint64_t mem) {
-  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_1G_MASK) >> 18;
-  uint64_t upper = (PAGE_PT_SELF_MAP << 39)
-                 | (PAGE_PT_SELF_MAP << 30);
-  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
-}
-
-static inline uint64_t PAGE_VIRT_PDPT_OF(uint64_t mem) {
-  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_HT_MASK) >> 27;
-  uint64_t upper = (PAGE_PT_SELF_MAP << 39)
-                 | (PAGE_PT_SELF_MAP << 30)
-                 | (PAGE_PT_SELF_MAP << 21);
-  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
-}
-
-static inline uint64_t PAGE_VIRT_PML4_OF(uint64_t mem) {
-  uint64_t lower = (mem & PAGE_VM_MASK & ~PAGE_VM_MASK) >> 36;
-  uint64_t upper = (PAGE_PT_SELF_MAP << 39)
-                 | (PAGE_PT_SELF_MAP << 30)
-                 | (PAGE_PT_SELF_MAP << 21)
-                 | (PAGE_PT_SELF_MAP << 12);
-  return PAGE_MAKE_CANONICAL_ADDR(lower | upper);
-}
+#include "page-constants.h"
 
 typedef uint64_t *pagetable;
 
@@ -85,7 +10,6 @@ void insert_pt (pagetable pt);
 pagetable get_current_pt (void);
 pagetable initial_pt (void);
 pagetable new_pt (void);
-int map_page (uint64_t phys, uint64_t virt, uint64_t mode);
 int unmap_page (uint64_t virt);
 int map_new_page (uint64_t virt, uint64_t mode);
 

--- a/kernel/page.h
+++ b/kernel/page.h
@@ -1,8 +1,10 @@
 #ifndef __SILVOS_PAGE_H
 #define __SILVOS_PAGE_H
 
-#include <stdint.h>
 #include "page-constants.h"
+#include "pagemap.h"
+
+#include <stdint.h>
 
 typedef uint64_t *pagetable;
 
@@ -12,5 +14,7 @@ pagetable initial_pt (void);
 pagetable new_pt (void);
 int unmap_page (uint64_t virt);
 int map_new_page (uint64_t virt, uint64_t mode);
+void clone_pagemap (pagemap *dst, pagemap *src);
+void apply_pagemap (void);
 
 #endif

--- a/kernel/pagefault.c
+++ b/kernel/pagefault.c
@@ -1,5 +1,6 @@
 #include "pagefault.h"
 
+#include "com.h"
 #include "util.h"
 #include "memory-map.h"
 #include "threads.h"
@@ -20,12 +21,21 @@ int check_addr (const void *low, const void *high) {
 jmp_buf for_copying;
 int is_copying;
 
-void pagefault_handler (void) {
+void pagefault_handler (uint64_t addr) {
   if (is_copying) {
     longjmp(for_copying, -1);
-  } else {
-    thread_exit_schedule();
   }
+  com_puts("Kernel: ");
+  com_put_tid();
+  com_puts(" page fault at ");
+  char pf_addr[] = "0x0000000000000000";
+  const char hex[] = "0123456789ABCDEF";
+  for (int i = 0; i < 16; ++i) {
+    pf_addr[sizeof(pf_addr) - 2 - i] = hex[0x0F & (addr >> (4 * i))];
+  }
+  com_puts(pf_addr);
+  com_putch('\n');
+  thread_exit_schedule();
 }
 
 

--- a/kernel/pagefault.h
+++ b/kernel/pagefault.h
@@ -2,8 +2,9 @@
 #define __SILVOS_PAGEFAULT_H
 
 #include <stddef.h>
+#include <stdint.h>
 
-void __attribute__ ((noreturn)) pagefault_handler (void);
+void __attribute__ ((noreturn)) pagefault_handler (uint64_t addr);
 
 int copy_from_user(void *to, const void *from, size_t count);
 int copy_to_user(void *to, const void *from, size_t count);

--- a/kernel/pagemap.c
+++ b/kernel/pagemap.c
@@ -1,0 +1,48 @@
+#include "pagemap.h"
+
+#include "page-constants.h"
+
+int pm_add_ent (pagemap *p, uint64_t virt, uint64_t phys) {
+  if (p->num_entries >= NUMMAPS) {
+    return -1;
+  }
+  p->entries[p->num_entries].virt = virt;
+  p->entries[p->num_entries].phys = phys;
+  ++p->num_entries;
+  return 0;
+}
+
+int pm_remove_ent (pagemap *p, uint8_t ix) {
+  if (ix >= p->num_entries) {
+    return -1;
+  }
+  p->entries[ix] = p->entries[p->num_entries - 1];
+  --p->num_entries;
+  return 0;
+}
+
+int pm_get_ent (const pagemap *p, uint64_t virt, pagemap_ent *out) {
+  for (int i = 0; i < p->num_entries; ++i) {
+    if (p->entries[i].virt == virt) {
+      if (out) {
+        *out = p->entries[i];
+      }
+      return 0;
+    }
+  }
+  return -1;
+}
+
+int pm_get_phys (const pagemap *p, uint64_t virt, uint64_t *phys) {
+  pagemap_ent ent;
+  int ret = pm_get_ent(p, virt, &ent);
+  if (phys && !ret) {
+    *phys = ent.phys;
+  }
+
+  return ret;
+}
+
+int pm_is_mapped (const pagemap *p, uint64_t virt) {
+  return pm_get_ent(p, virt, 0) == 0;
+}

--- a/kernel/pagemap.h
+++ b/kernel/pagemap.h
@@ -1,0 +1,24 @@
+#ifndef __SILVOS_PAGE_MAP_H
+#define __SILVOS_PAGE_MAP_H
+#include <stdint.h>
+
+#define NUMMAPS 32
+
+typedef struct {
+  uint64_t virt;
+  uint64_t phys;
+} pagemap_ent;
+
+typedef struct {
+  pagemap_ent entries[NUMMAPS];
+  uint8_t num_entries;
+} pagemap;
+
+int pm_add_ent (pagemap *p, uint64_t virt, uint64_t phys);
+int pm_remove_ent (pagemap *p, uint8_t ix);
+int pm_get_ent (const pagemap *p, uint64_t virt, pagemap_ent *out);
+int pm_get_phys (const pagemap *p, uint64_t virt, uint64_t *phys);
+/* Returns 1 if present, 0 if not present. */
+int pm_is_mapped (const pagemap *p, uint64_t virt);
+
+#endif

--- a/kernel/palloc.c
+++ b/kernel/palloc.c
@@ -5,15 +5,11 @@
 #include "page.h"
 
 int palloc (void *virt_addr) {
-  int error = pfree(virt_addr); /* Don't lose track of the old page */
-  if (error) {
-    return error;
-  }
   uint64_t v = (uint64_t)virt_addr;
   if (v & PAGE_4K_MASK) {
     return -2;
   }
-  if (v >= LOC_USERZONE_TOP) {
+  if (v >= LOC_USERZONE_TOP || v < LOC_USERZONE_BOT) {
     return -3;
   }
   return map_new_page(v, PAGE_MASK__USER);
@@ -24,7 +20,7 @@ int pfree (void *virt_addr) {
   if (v & PAGE_4K_MASK) {
     return -2;
   }
-  if (v >= LOC_USERZONE_TOP) {
+  if (v >= LOC_USERZONE_TOP || v < LOC_USERZONE_BOT) {
     return -3;
   }
   return unmap_page(v);

--- a/kernel/syscall-asm.s
+++ b/kernel/syscall-asm.s
@@ -11,3 +11,4 @@ syscall_defns:
 	.quad pfree
 	.quad com_debug_thread
 	.quad hpet_nanosleep
+	.quad fork

--- a/kernel/syscall-defs.h
+++ b/kernel/syscall-defs.h
@@ -13,7 +13,8 @@ typedef unsigned long long syscall_arg;
 #define SYSCALL_PFREE       0x07
 #define SYSCALL_DEBUG       0x08
 #define SYSCALL_NANOSLEEP   0x09
+#define SYSCALL_FORK        0x0A
 
-#define NUM_SYSCALLS        0x0A
+#define NUM_SYSCALLS        0x0B
 
 #endif

--- a/kernel/threads-asm.s
+++ b/kernel/threads-asm.s
@@ -1,3 +1,21 @@
+.macro push_callee_save_reg
+        push %rbx
+        push %rbp
+        push %r12
+        push %r13
+        push %r14
+        push %r15
+.endm
+
+.macro pop_callee_save_reg
+        pop %r15
+        pop %r14
+        pop %r13
+        pop %r12
+        pop %rbp
+        pop %rbx
+.endm
+
 .GLOBAL thread_start
 thread_start:
         iretq
@@ -9,26 +27,33 @@ user_thread_start:
 
 .GLOBAL schedule
 schedule:
-        /* Push callee-save registers */
-        push %rbx
-        push %rbp
-        push %r12
-        push %r13
-        push %r14
-        push %r15
-
+        push_callee_save_reg
         mov %rsp,(schedule_rsp)
         call schedule_helper
         mov (schedule_rsp),%rsp
         mov (schedule_pt),%rdi
         call insert_pt
-
-        /* Pop callee-save registers */
-        pop %r15
-        pop %r14
-        pop %r13
-        pop %r12
-        pop %rbp
-        pop %rbx
-
+        pop_callee_save_reg
         ret
+
+.GLOBAL fork
+fork:
+	call fork_entry_point
+	/* Both parent and child return here. The parent returns immediately,
+	 * so fork_ret will contain 0 for the child. */
+	mov (fork_ret),%edi
+	movq $0,(fork_ret)
+	call finish_fork
+	ret
+
+fork_entry_point:
+	push_callee_save_reg
+	/* We will copy everything above us to the child's new kernel stack.
+	 * This means the child will exit insert_pt (in schedule) with an exact
+	 * copy of the current stack; above us is all callee-save registers
+	 * followed by the return address into fork, then the syscall stack. */
+	mov %rsp,%rdi
+	call clone_thread
+	mov %eax,(fork_ret)
+	pop_callee_save_reg
+	ret

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -16,13 +16,10 @@
 
 tcb tcbs[NUMTHREADS];
 
-
-/* Returns 0 on success, negative on failure */
-int user_thread_create (void *text, size_t length) {
+/* After calling this, you must set up the kernel stack contents, rsp, and fpu
+ * state if not INACTIVE. Returns null on failure. */
+tcb *create_thread (void* text, size_t length) {
   static uint8_t thread_id = 1;
-  if (elf64_check(text, length)) {
-    return -2; /* Bad elf! */
-  }
   for (int i = 0; i < NUMTHREADS; i++) {
     if (tcbs[i].state == TS_NONEXIST) {
       tcbs[i].thread_id = thread_id++;
@@ -30,26 +27,38 @@ int user_thread_create (void *text, size_t length) {
       tcbs[i].pt = new_pt();
       tcbs[i].text = text;
       tcbs[i].text_length = length;
-      /* Set up stacks */
-      uint64_t *kernel_stack = &((uint64_t *)allocate_phys_page())[512];
-      /* Initialize tcb struct */
+      char *kernel_stack = &((char *)allocate_phys_page())[4096];
       tcbs[i].state = TS_INACTIVE;
       tcbs[i].stack_top = &kernel_stack[0];
-      /* Initialize stack */
-      /* Stack frame one:  user_thread_start */
-      kernel_stack[-1] = 0x1B;                         /* %ss */
-      kernel_stack[-2] = (uint64_t)LOC_USER_STACKTOP;  /* %rsp */
-      kernel_stack[-3] = 0x200;                        /* EFLAGS */
-      kernel_stack[-4] = 0x4B;                         /* %cs */
-      kernel_stack[-5] = elf64_get_entry(text);        /* %rip */
-      /* Stack frame two:  schedule */
-      kernel_stack[-6] = (uint64_t)user_thread_start;  /* %rip */
-      /* 6 callee-save registers */
-      tcbs[i].rsp = &kernel_stack[-12];
       tcbs[i].fpu_state = THREAD_FPU_STATE_INACTIVE;
-      return 0;
+      return &tcbs[i];
     }
   }
+  return 0;
+}
+
+/* Returns 0 on success, negative on failure */
+int user_thread_create (void *text, size_t length) {
+  if (elf64_check(text, length)) {
+    return -2; /* Bad elf! */
+  }
+  tcb *new_tcb = create_thread(text, length);
+  if (!new_tcb) {
+    return -1;
+  }
+
+  uint64_t *kernel_stack = (uint64_t *)new_tcb->stack_top;
+  /* Initialize stack */
+  /* Stack frame one:  user_thread_start */
+  kernel_stack[-1] = 0x1B;                         /* %ss */
+  kernel_stack[-2] = (uint64_t)LOC_USER_STACKTOP;  /* %rsp */
+  kernel_stack[-3] = 0x200;                        /* EFLAGS */
+  kernel_stack[-4] = 0x4B;                         /* %cs */
+  kernel_stack[-5] = elf64_get_entry(text);        /* %rip */
+  /* Stack frame two:  schedule */
+  kernel_stack[-6] = (uint64_t)user_thread_start;  /* %rip */
+  /* 6 callee-save registers */
+  new_tcb->rsp = &kernel_stack[-12];
   return -1; /* No thread available! */
 }
 
@@ -145,4 +154,35 @@ void thread_exit_schedule (void) {
 void block_current_thread (void) {
   running_tcb->state = TS_BLOCKED;
   schedule();
+}
+
+int fork_ret = 0;
+
+int clone_thread (uint64_t fork_rsp) {
+  tcb *new_tcb = create_thread(running_tcb->text, running_tcb->text_length);
+  if (!new_tcb) {
+    return -1;
+  }
+
+  clone_pagemap(&new_tcb->pm, &running_tcb->pm);
+  /* Clone kernel stack starting at fork_entry_point. */
+  uint64_t stack_depth = (uint64_t) running_tcb->stack_top - fork_rsp;
+  memcpy(((char *)new_tcb->stack_top) - stack_depth,
+         ((char *)running_tcb->stack_top) - stack_depth, stack_depth);
+  new_tcb->rsp = ((char*)new_tcb->stack_top) - stack_depth;
+  new_tcb->fpu_state = running_tcb->fpu_state;
+  if (new_tcb->fpu_state == THREAD_FPU_STATE_ACTIVE) {
+    new_tcb->fpu_buf = allocate_phys_page();
+    memcpy(&new_tcb->fpu_buf, &running_tcb->fpu_buf, sizeof(running_tcb->fpu_buf));
+  }
+  return new_tcb->thread_id;
+}
+
+int finish_fork (int thread_id) {
+  if (thread_id) {
+    /* Parent case: nothing to do, yet. */
+    return thread_id;
+  }
+  apply_pagemap();
+  return thread_id;
 }

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -16,6 +16,7 @@
 
 tcb tcbs[NUMTHREADS];
 
+
 /* Returns 0 on success, negative on failure */
 int user_thread_create (void *text, size_t length) {
   static uint8_t thread_id = 1;
@@ -25,6 +26,7 @@ int user_thread_create (void *text, size_t length) {
   for (int i = 0; i < NUMTHREADS; i++) {
     if (tcbs[i].state == TS_NONEXIST) {
       tcbs[i].thread_id = thread_id++;
+      tcbs[i].pm.num_entries = 0;
       tcbs[i].pt = new_pt();
       tcbs[i].text = text;
       tcbs[i].text_length = length;
@@ -67,6 +69,7 @@ void idle () {
 int idle_thread_create () {
   idle_tcb.thread_id = 0;
   idle_tcb.state = TS_INACTIVE;
+  idle_tcb.pm.num_entries = 0;
   idle_tcb.pt = new_pt();
   /* Set up stack */
   uint64_t *idle_stack = &((uint64_t *)allocate_phys_page())[512];

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -3,6 +3,7 @@
 
 #include "list.h"
 #include "page.h"
+#include "pagemap.h"
 
 #include <stdint.h>
 #include <stddef.h>
@@ -34,6 +35,7 @@ typedef struct {
   size_t text_length;
   enum fpu_state fpu_state;
   char (*fpu_buf)[512];
+  pagemap pm;
 } tcb;
 
 extern tcb *running_tcb;

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -53,6 +53,8 @@ void user_thread_start (void);
 void user_thread_launch (void);
 void schedule (void);
 int idle_thread_create (void);
+int clone_thread (uint64_t fork_rsp);
+int finish_fork (int thread_id);
 
 
 #define wait_event(wq, cond)                      \

--- a/userland/test-memory/expected.txt
+++ b/userland/test-memory/expected.txt
@@ -1,6 +1,16 @@
+THREAD 0x01: Allocating
+THREAD 0x01: Forking
+THREAD 0x01: Parent
+THREAD 0x02: Child
 THREAD 0x01: Writing
+THREAD 0x02: Writing
 THREAD 0x01: Reading
+THREAD 0x02: Reading
 THREAD 0x01: Freeing
+THREAD 0x02: Freeing
 THREAD 0x01: Reading
+THREAD 0x02: Reading
 THREAD 0x01: Page faulting
 Kernel: THREAD 0x01 page fault at 0x0000000000004000
+THREAD 0x02: Page faulting
+Kernel: THREAD 0x02 page fault at 0x0000000000004000

--- a/userland/test-memory/expected.txt
+++ b/userland/test-memory/expected.txt
@@ -3,3 +3,4 @@ THREAD 0x01: Reading
 THREAD 0x01: Freeing
 THREAD 0x01: Reading
 THREAD 0x01: Page faulting
+Kernel: THREAD 0x01 page fault at 0x0000000000004000

--- a/userland/userland.h
+++ b/userland/userland.h
@@ -68,4 +68,8 @@ static inline void nanosleep (long long usecs) {
   __syscall1(SYSCALL_NANOSLEEP, usecs);
 }
 
+static inline int fork () {
+  return (int)__syscall0(SYSCALL_FORK);
+}
+
 #endif


### PR DESCRIPTION
- Keep track of what pages users allocate in a pagemap struct
- On a fork(), copy all mapped pages while interpreting the syscall in the parent.
- We don't actually remap the pages (in the child's pagetable) until it gets scheduled (code runs in finish_fork(0)).
- test-memory now tests that fork() behaves as expected
- the pagefault handler now prints the address that faulted and the thread id.
- I'm definitely not sure if the fpu state is properly carried over