### PR TITLE
Threads simplification

### DIFF
--- a/kernel/threads-asm.s
+++ b/kernel/threads-asm.s
@@ -36,6 +36,11 @@ schedule:
         pop_callee_save_reg
         ret
 
+.section .bss
+.comm fork_ret,4,4
+
+.text
+
 .GLOBAL fork
 fork:
 	call fork_entry_point
@@ -56,4 +61,16 @@ fork_entry_point:
 	call clone_thread
 	mov %eax,(fork_ret)
 	pop_callee_save_reg
+	ret
+
+finish_fork:
+	testl	%edi, %edi
+	pushq	%rbx
+	movl	%edi, %ebx
+	/* if the fork_ret was not zero, we are in the parent and can just return */
+	jne     finish_fork_child
+	call	apply_pagemap
+finish_fork_child:
+	movl	%ebx, %eax
+	popq	%rbx
 	ret

--- a/kernel/threads-asm.s
+++ b/kernel/threads-asm.s
@@ -18,11 +18,7 @@
 
 .GLOBAL thread_start
 thread_start:
-        iretq
-
-.GLOBAL user_thread_start
-user_thread_start:
-        call user_thread_launch
+	call thread_launch
         iretq
 
 .GLOBAL schedule

--- a/kernel/threads-asm.s
+++ b/kernel/threads-asm.s
@@ -24,10 +24,15 @@ thread_start:
 .GLOBAL schedule
 schedule:
         push_callee_save_reg
-        mov %rsp,(schedule_rsp)
+	mov (running_tcb), %rbx
+	test %rbx, %rbx
+	jz dont_save_rsp
+        mov %rsp,0x10(%rbx) /* saved rsp is first in the tcb after queue */
+dont_save_rsp:
         call schedule_helper
-        mov (schedule_rsp),%rsp
-        mov (schedule_pt),%rdi
+	mov (running_tcb), %rbx
+        mov 0x10(%rbx),%rsp
+        mov 0x18(%rbx),%rdi
         call insert_pt
         pop_callee_save_reg
         ret

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -15,8 +15,6 @@
 #include <stddef.h>
 
 tcb *running_tcb = 0;
-void *schedule_rsp;
-pagetable schedule_pt;
 
 static tcb tcbs[NUMTHREADS];
 static int32_t total_threads = -1;  /* The idle thread doesn't count. */
@@ -120,15 +118,10 @@ static tcb *choose_task (void) {
 }
 
 void schedule_helper (void) {
-  if (running_tcb) {
-    running_tcb->rsp = schedule_rsp;
-  }
   running_tcb = choose_task();
   hpet_reset_timeout(); /* Reset pre-emption timer */
   set_new_rsp(running_tcb->stack_top);
   fpu_switch_thread();
-  schedule_rsp = running_tcb->rsp;
-  schedule_pt = running_tcb->pt;
 }
 
 void thread_exit (void) {

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -14,14 +14,18 @@
 #include <stdint.h>
 #include <stddef.h>
 
-tcb tcbs[NUMTHREADS];
+tcb *running_tcb = 0;
+void *schedule_rsp;
+pagetable schedule_pt;
 
-int32_t total_threads = -1;  /* The idle thread doesn't count. */
+static tcb tcbs[NUMTHREADS];
+static int32_t total_threads = -1;  /* The idle thread doesn't count. */
+static tcb *idle_tcb = 0;
 
 /* After calling this, you must set up the kernel stack contents, rsp, and fpu
  * state if not INACTIVE. Returns null on failure.  If you want the thread to
  * ever be scheduled, you must call 'reschedule_thread' on it. */
-tcb *create_thread (void* text, size_t length) {
+static tcb *create_thread (void* text, size_t length) {
   static uint8_t thread_id = 0;
   for (int i = 0; i < NUMTHREADS; i++) {
     if (tcbs[i].state == TS_NONEXIST) {
@@ -83,13 +87,11 @@ void user_thread_launch () {
   map_new_page(LOC_USER_STACK, PAGE_MASK__USER | PAGE_MASK_NX);
 }
 
-void idle () {
+static void idle () {
   while (1) {
     hlt();
   }
 }
-
-tcb *idle_tcb = 0;
 
 int idle_thread_create () {
   idle_tcb = create_thread_internal(1, NULL, 0, (uint64_t)idle);
@@ -104,7 +106,7 @@ int idle_thread_create () {
 LIST_HEAD(schedule_queue);
 
 /* Round-robin scheduling. */
-tcb *choose_task (void) {
+static tcb *choose_task (void) {
   if (total_threads == 0) {
     /* All threads have exited.  Power off. */
     qemu_debug_shutdown();
@@ -112,11 +114,6 @@ tcb *choose_task (void) {
   tcb *result = (tcb *)list_pop_front(&schedule_queue);
   return result ? result : idle_tcb;
 }
-
-tcb *running_tcb = 0;
-
-void *schedule_rsp;
-pagetable schedule_pt;
 
 void schedule_helper (void) {
   if (running_tcb) {
@@ -150,8 +147,6 @@ void yield (void) {
   schedule();
 }
 
-int fork_ret = 0;
-
 int clone_thread (uint64_t fork_rsp) {
   tcb *new_tcb = create_thread(running_tcb->text, running_tcb->text_length);
   if (!new_tcb) {
@@ -171,13 +166,4 @@ int clone_thread (uint64_t fork_rsp) {
   }
   reschedule_thread(new_tcb);
   return new_tcb->thread_id;
-}
-
-int finish_fork (int thread_id) {
-  if (thread_id) {
-    /* Parent case: nothing to do, yet. */
-    return thread_id;
-  }
-  apply_pagemap();
-  return thread_id;
 }

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -49,8 +49,7 @@ void reschedule_thread (tcb *thread);
 void yield (void);
 
 void thread_start (void);
-void user_thread_start (void);
-void user_thread_launch (void);
+void thread_launch (void);
 void __attribute__((noreturn)) thread_exit (void);
 
 int clone_thread (uint64_t fork_rsp);

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -24,11 +24,15 @@ enum fpu_state {
 
 typedef struct {
   struct list_head wait_queue;
+
+  /* These are referenced in ASM in threads-asm.s, so their offsets
+     must be well-known */
+  void *rsp;        /* Kernel stack pointer, when yielded */
+  pagetable pt;
+
   uint8_t thread_id;
   enum thread_state state;
-  void *rsp;        /* Kernel stack pointer, when yielded */
   void *stack_top;  /* For TSS usage */
-  pagetable pt;
   void *text;
   size_t text_length;
   enum fpu_state fpu_state;
@@ -37,8 +41,6 @@ typedef struct {
 } tcb;
 
 extern tcb *running_tcb;
-extern void *schedule_rsp;
-extern pagetable schedule_pt;
 
 int user_thread_create (void *text, size_t length);
 int idle_thread_create (void);

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -37,20 +37,23 @@ typedef struct {
 } tcb;
 
 extern tcb *running_tcb;
+extern void *schedule_rsp;
+extern pagetable schedule_pt;
 
 int user_thread_create (void *text, size_t length);
-void schedule_helper (void);
-void __attribute__((noreturn)) thread_exit (void);
-void thread_start (void);
-void user_thread_start (void);
-void user_thread_launch (void);
-void schedule (void);
 int idle_thread_create (void);
-int clone_thread (uint64_t fork_rsp);
-int finish_fork (int thread_id);
+
+void schedule (void);
+void schedule_helper (void);
 void reschedule_thread (tcb *thread);
 void yield (void);
 
+void thread_start (void);
+void user_thread_start (void);
+void user_thread_launch (void);
+void __attribute__((noreturn)) thread_exit (void);
+
+int clone_thread (uint64_t fork_rsp);
 
 #define wait_event(wq, cond)                       \
 do {                                               \


### PR DESCRIPTION
This commit simplifies a lot of stuff w.r.t. threads.c and threads-asm.s in an attempt to make it more readable and to make the control flow more obvious.

It:
- Factors out the idle thread and user thread tcb creation into one function.
- Unifies thread launching for the idle thread and the user threads.
- Moves some variables and functions that do not need to be in threads.c to threads-asm.s only.
- Makes functions and variables in threads.c that do not need to be public static.
- Adds a panic in the case that the idle thread cannot be allocated, instead of a silent error.
- Fixes the return value of user_thread_create on succcess.

Open Questions:
- Should schedule_helper be implemented entirely in assembly? It doesn't really get anything out of being implemented in C and it just makes the code more complicated.
