### PR TITLE
More cleanup of threads-asm.s

### DIFF
--- a/kernel/threads-asm.s
+++ b/kernel/threads-asm.s
@@ -23,19 +23,13 @@ thread_start:
 
 .GLOBAL schedule
 schedule:
-        push_callee_save_reg
-	mov (running_tcb), %rbx
-	test %rbx, %rbx
-	jz dont_save_rsp
-        mov %rsp,0x10(%rbx) /* saved rsp is first in the tcb after queue */
-dont_save_rsp:
-        call schedule_helper
-	mov (running_tcb), %rbx
-        mov 0x10(%rbx),%rsp
-        mov 0x18(%rbx),%rdi
-        call insert_pt
-        pop_callee_save_reg
-        ret
+	push_callee_save_reg
+	mov %rsp,%rdi
+	call start_context_switch
+	mov %rax,%rsp  /* Switch stacks here! */
+	call finish_context_switch
+	pop_callee_save_reg
+	ret
 
 .section .bss
 .comm fork_ret,4,4

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -21,15 +21,10 @@ enum fpu_state {
   THREAD_FPU_STATE_ACTIVE,    /* there's an FPU buf allocated */
 };
 
-
 typedef struct {
   struct list_head wait_queue;
-
-  /* These are referenced in ASM in threads-asm.s, so their offsets
-     must be well-known */
   void *rsp;        /* Kernel stack pointer, when yielded */
   pagetable pt;
-
   uint8_t thread_id;
   enum thread_state state;
   void *stack_top;  /* For TSS usage */
@@ -46,12 +41,10 @@ int user_thread_create (void *text, size_t length);
 int idle_thread_create (void);
 
 void schedule (void);
-void schedule_helper (void);
 void reschedule_thread (tcb *thread);
 void yield (void);
 
 void thread_start (void);
-void thread_launch (void);
 void __attribute__((noreturn)) thread_exit (void);
 
 int clone_thread (uint64_t fork_rsp);


### PR DESCRIPTION
Now we don't need to reference the struct from assembly.  It's a little
awkward having the two C helper functions, but I think this is pretty clean.