### PR TITLE
Fix bug where fork() breaks at -O0

### DIFF
--- a/kernel/threads-asm.s
+++ b/kernel/threads-asm.s
@@ -31,6 +31,16 @@ schedule:
 	pop_callee_save_reg
 	ret
 
+/* fork must be written in assembly, so we know that no stack pointers are put
+ * in registers or on the stack---those will break when we move to a new stack.
+ */
+
+.GLOBAL fork
+fork:
+	call fork_entry_point
+	call fork_get_return_val
+	ret
+
 /* fork_entry_point and schedule's stack frames must look the same: when
  * forking, the stack is copied while in fork_entry_point, but the child
  * resumes into schedule instead.  Both parent and child return into 'fork',

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -183,8 +183,7 @@ void clone_thread (uint64_t fork_rsp) {
   fork_pid = new_tcb->thread_id;
 }
 
-int fork (void) {
-  fork_entry_point(); /* This call returns twice */
+int fork_get_return_val (void) {
   int res = fork_pid;
   fork_pid = 0;
   return res;

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -44,7 +44,6 @@ void yield (void);
 
 void thread_start (void);
 void __attribute__((noreturn)) thread_exit (void);
-void __attribute__((returns_twice)) fork_entry_point (void);
 
 void clone_thread (uint64_t fork_rsp);
 


### PR DESCRIPTION
At -O0, gcc stores frame pointers in %rbp and on the stack.  These don't work
so well when you copy the stack to an entirely new location.  To fix this, put
'fork' back into assembly so that all the copied stack frames are in pure
assembly.  The logic of the return value is now in its own C function.