### PR TITLE
Fix optimization issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,17 @@ TEST_PROGS := $(patsubst userland/%/expected.txt, %, $(wildcard userland/*/expec
 
 USERLAND_PROGS := $(patsubst userland/%/main.c, %, $(wildcard userland/*/main.c))
 
-KERN_CFLAGS := -ffreestanding -mno-red-zone -Wall -Wextra -std=c99 -O2 -g -mcmodel=kernel
-KERN_LDFLAGS := -nostdlib -lgcc -Wl,-z,max-page-size=0x1000 -mcmodel=kernel
+# Ideally, the kernel should compile and pass all tests with all of these
+#KERNEL_OPT := -O0
+#KERNEL_OPT := -O1
+KERNEL_OPT := -O2
+#KERNEL_OPT := -O3
+#KERNEL_OPT := -Os
+KERNEL_OPT += -g
+#KERNEL_OPT += -flto
+
+KERN_CFLAGS := -ffreestanding -mno-red-zone -Wall -Wextra -std=c99 -mno-mmx -mno-sse -mno-sse2 -mcmodel=kernel $(KERNEL_OPT)
+KERN_LDFLAGS := -nostdlib -lgcc -Wl,-z,max-page-size=0x1000 -mcmodel=kernel -mno-mmx -mno-sse -mno-sse2 $(KERNEL_OPT)
 
 BOOTLOADER_CFLAGS := -ffreestanding -mno-red-zone -Wall -Wextra -std=c99 -O2 -g
 BOOTLOADER_LDFLAGS := -nostdlib -Wl,--no-warn-mismatch -Wl,-z,max-page-size=0x1000

--- a/kernel/hpet.c
+++ b/kernel/hpet.c
@@ -86,7 +86,7 @@ void hpet_nanosleep (uint64_t usecs) {
    * sleeping for small enough amounts of time that they get control back
    * immediately. */
   schedule();
-};
+}
 
 void hpet_sleepers_awake() {
   while (1) {

--- a/kernel/hpet.h
+++ b/kernel/hpet.h
@@ -43,7 +43,7 @@ static const uint64_t HPET_CAPABILITIES_CLK_PERIOD      = 0xFFFFFFFF00000000;  /
 static const uint64_t HPET_GENERAL_CONFIG_ENABLE        = 0x01;
 static const uint64_t HPET_GENERAL_CONFIG_LEGACY_ROUTE  = 0x02;
 
-struct HPET_Registers *hpet_reg;
+volatile struct HPET_Registers *hpet_reg;
 
 int hpet_initialize (void);
 void hpet_reset_timeout (void);


### PR DESCRIPTION
This fixes two kernel optimization issues:

- The kernel should not generate code that uses MMX registers. Disable those instruction sets that are implied by 64-bit (MMX, SSE, SSE2) in the kernel.
- HPET_Registers needs to be marked as volatile to have the nanosleep test pass at -O3. It is, after all, volatile, so this seems like a reasonable fix.