### PR TITLE
Add printf and use it instead of com_ functions where appropriate.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ userland/*.bin
 userland/*/output.txt
 userland/*/coverage.log
 userland/*/test_disk
+tests/*/output.txt

--- a/kernel/com.c
+++ b/kernel/com.c
@@ -50,7 +50,7 @@ int com_printf (const char *fmt, ...) {
   int ret;
   va_list argp;
   va_start(argp, fmt);
-  ret = vprintf(com_putch, fmt, argp);
+  ret = kvprintf(com_putch, fmt, argp);
   va_end(argp);
   return ret;
 }

--- a/kernel/com.c
+++ b/kernel/com.c
@@ -5,6 +5,7 @@
 #include "threads.h"
 #include "util.h"
 
+#include <stdarg.h>
 #include <stddef.h>
 
 static const uint16_t PORT = 0x3f8;
@@ -40,9 +41,16 @@ uint32_t com_debug_thread (char *text, uint32_t len) {
     return 0;
   }
   tmp[len] = 0;
-  printf("THREAD 0x%02x: %s\n", running_tcb->thread_id, tmp);
+  com_printf("THREAD 0x%02X: %s\n", running_tcb->thread_id, tmp);
 
   return len;
 }
 
-
+int com_printf (const char *fmt, ...) {
+  int ret;
+  va_list argp;
+  va_start(argp, fmt);
+  ret = vprintf(com_putch, fmt, argp);
+  va_end(argp);
+  return ret;
+}

--- a/kernel/com.c
+++ b/kernel/com.c
@@ -1,6 +1,7 @@
 #include "com.h"
 
 #include "pagefault.h"
+#include "printf.h"
 #include "threads.h"
 #include "util.h"
 
@@ -28,36 +29,19 @@ void com_puts (const char *text) {
   }
 }
 
-void com_put_tid (void) {
-  const char header[] = "THREAD 0x";
-  for (size_t i = 0; header[i]; i++) {
-    com_putch(header[i]);
-  }
-  const char hex[] = "0123456789ABCDEF";
-  uint8_t t = running_tcb->thread_id;
-  com_putch(hex[0x0F & (t >> 4)]);
-  com_putch(hex[0x0F & t]);
-}
-
 uint32_t com_debug_thread (char *text, uint32_t len) {
   /* TODO: check that user text is nice (doesn't contain control characters,
    * for intance) */
-  char tmp[60];
+  char tmp[61];
   if (len > 60) {
     len = 60;
   }
   if (copy_from_user(&tmp[0], text, len)) {
     return 0;
   }
-  com_put_tid();
-  com_putch(':');
-  com_putch(' ');
+  tmp[len] = 0;
+  printf("THREAD 0x%02x: %s\n", running_tcb->thread_id, tmp);
 
-  for (size_t i = 0; (i < len) && tmp[i]; i++) {
-    com_putch(tmp[i]);
-  }
-
-  com_putch('\n');
   return len;
 }
 

--- a/kernel/com.h
+++ b/kernel/com.h
@@ -7,7 +7,6 @@
 void com_initialize (void);
 void com_putch (char c);
 void com_puts (const char *text);
-void com_put_tid (void);
 uint32_t com_debug_thread (char *text, uint32_t len);
 
 #endif

--- a/kernel/com.h
+++ b/kernel/com.h
@@ -7,6 +7,7 @@
 void com_initialize (void);
 void com_putch (char c);
 void com_puts (const char *text);
+int com_printf (const char *fmt, ...);
 uint32_t com_debug_thread (char *text, uint32_t len);
 
 #endif

--- a/kernel/pagefault.c
+++ b/kernel/pagefault.c
@@ -1,7 +1,7 @@
 #include "pagefault.h"
 
+#include "com.h"
 #include "memory-map.h"
-#include "printf.h"
 #include "threads.h"
 #include "util.h"
 
@@ -26,11 +26,11 @@ void pagefault_handler (uint64_t addr) {
     longjmp(for_copying, -1);
   }
   if (running_tcb) {
-    printf("Kernel page fault at %p, running thread is %x.\n", (void *)addr, running_tcb->thread_id);
+    com_printf("Kernel page fault at %p, running thread is 0x%02X.\n", (void *)addr, running_tcb->thread_id);
     thread_exit();
   } else {
-    printf("Kernel page fault at %p, no running thread! Panic!\n", (void *)addr);
-    qemu_debug_shutdown("Page fault with no running thread!);
+    com_printf("Kernel page fault at %p, no running thread! Panic!\n", (void *)addr);
+    panic("Page fault with no running thread!");
   }
 }
 

--- a/kernel/pci.c
+++ b/kernel/pci.c
@@ -1,8 +1,8 @@
 #include "pci.h"
 
-#include "util.h"
-#include "vga.h"
 #include "ide.h"
+#include "vga.h"
+#include "util.h"
 
 typedef void (*pci_device_init)(uint8_t bus, uint8_t device, uint8_t function);
 
@@ -24,17 +24,6 @@ static pci_handler pci_handlers[] = {
 
 void initialize_device (uint8_t bus, uint8_t device, uint8_t function, uint16_t vendor) {
   uint16_t class_subclass = pci_read(2, function, device, bus) >> 16;
-  puts("PCI ");
-  put_byte(bus);
-  putc(':');
-  put_byte(device);
-  putc('.');
-  put_byte(function);
-  puts(" (class: ");
-  put_short(class_subclass);
-  puts(" vendor: ");
-  put_short(vendor);
-  puts(") ");
   const char *name = "Unknown";
   pci_device_init initializer = NULL;
   for (pci_handler *h = pci_handlers; h->name != NULL; h++) {
@@ -44,11 +33,9 @@ void initialize_device (uint8_t bus, uint8_t device, uint8_t function, uint16_t 
       break;
     }
   }
-  puts(name);
-  if (initializer == NULL) {
-    puts(" (Unhandled)");
-  }
-  puts("\r\n");
+  vga_printf("PCI %02x:%02x.%02x (class: %04hx vendor: %04hx) %s%s\r\n",
+             bus, device, function, class_subclass, vendor,
+             name, initializer == NULL ? " (Unhandled)" : "");
   if (initializer != NULL) {
     initializer(bus, device, function);
   }

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -1,0 +1,274 @@
+#include "printf.h"
+
+#include "com.h"
+#include "util.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define emit(c) do { com_putch(c); ++ret; } while(0)
+#define emits(s) do { const char *_c = (s); \
+                      while (*_c) { emit(*(_c++)); } } while(0)
+
+#define FLAGS_LEFT_JUST 0x01
+#define FLAGS_USE_PLUS  0x02
+#define FLAGS_USE_SPACE 0x04
+#define FLAGS_ZERO_PAD  0x08
+
+enum arg_size {
+  SIZE_SHORT,
+  SIZE_DEFAULT,
+  SIZE_LONG,
+};
+
+typedef struct {
+  char fmt;
+  enum arg_size size;
+  uint8_t bitlength;
+  uint64_t min_width;
+  int flags;
+  union {
+    uint64_t uarg;
+    int64_t sarg;
+    char charg;
+    const char *strarg;
+  } arg;
+  /* Long enough for decimal 2**64-1 + NUL */
+  char work[22];
+  /* Contains NULL, " ", "+", "-", or "0x" depending on flags/arg sign/fmt */
+  const char* prefix;
+} format;
+
+/* Returns number of consumed characters. If this function reaches a null byte,
+ * str[return_value] will be zero. Otherwise, str[return_value] is the first
+ * character after the format string blob. */
+static int parse_fmt_string(const char *fmt, format *fspec) {
+  int i = 0;
+  char c = fmt[i];
+  fspec->flags = 0;
+  while (c) {
+    if (c == '-') {
+      fspec->flags |= FLAGS_LEFT_JUST;
+    } else if (c == '+') {
+      fspec->flags |= FLAGS_USE_PLUS;
+    } else if (c == '0') {
+      fspec->flags |= FLAGS_ZERO_PAD;
+    } else if (c == ' ') {
+      fspec->flags |= FLAGS_USE_SPACE;
+    } else {
+      break;
+    }
+    c = fmt[++i];
+  }
+  if (c == 0)  return i;
+
+  fspec->min_width = 0;
+  while (c) {
+    if ('0' <= c && c <= '9') {
+      fspec->min_width = fspec->min_width * 10 + (c - '0');
+      c = fmt[++i];
+    } else {
+      break;
+    }
+  }
+  if (c == 0)  return i;
+
+  fspec->size = SIZE_DEFAULT;
+  if (c == 'h') {
+    fspec->size = SIZE_SHORT;
+    c = fmt[++i];
+  } else if (c == 'l') {
+    fspec->size = SIZE_LONG;
+    c = fmt[++i];
+  }
+  if (c == 0)  return i;
+
+  fspec->fmt = c;
+  ++i;
+  return i;
+}
+
+/* Consumes the approprite amount from argp to read the argument specified by
+ * fspec->fmt, and sets some other state values based on the fmt and, for
+ * %d and %i, the sign of the argument that was read. */
+static int read_arg(format *fspec, va_list argp) {
+  fspec->prefix = NULL;
+  switch (fspec->fmt) {
+    case 'x':
+    case 'X':
+    case 'o':
+    case 'u':
+      switch (fspec->size) {
+        case SIZE_SHORT:
+          fspec->bitlength = 16;
+          fspec->arg.uarg = (uint16_t) va_arg(argp, int);
+          break;
+        case SIZE_DEFAULT:
+          fspec->bitlength = 32;
+          fspec->arg.uarg = va_arg(argp, uint32_t);
+          break;
+        case SIZE_LONG:
+          fspec->bitlength = 64;
+          fspec->arg.uarg = va_arg(argp, uint64_t);
+          break;
+      }
+      break;
+    case 'd':
+    case 'i':
+      switch (fspec->size) {
+        case SIZE_SHORT:
+          fspec->bitlength = 16;
+          fspec->arg.sarg = (int16_t) va_arg(argp, int);
+          break;
+        case SIZE_DEFAULT:
+          fspec->bitlength = 32;
+          fspec->arg.sarg = va_arg(argp, int32_t);
+          break;
+        case SIZE_LONG:
+          fspec->bitlength = 64;
+          fspec->arg.sarg = va_arg(argp, int64_t);
+          break;
+      }
+      if (fspec->arg.sarg < 0) {
+        fspec->prefix = "-";
+      } else if (fspec->flags & FLAGS_USE_PLUS) {
+        fspec->prefix = "+";
+      } else if (fspec->flags & FLAGS_USE_SPACE) {
+        fspec->prefix = " ";
+      }
+      break;
+    case 'p':
+      fspec->bitlength = 64;
+      fspec->arg.uarg = va_arg(argp, uint64_t);
+      fspec->prefix = "0x";
+      break;
+    case 'c':
+      fspec->arg.charg = (char) va_arg(argp, int);
+      break;
+    case 's':
+      fspec->arg.strarg = va_arg(argp, const char*);
+      break;
+    default:
+      return -1;
+  }
+
+  return 0;
+}
+
+/* Writes the representation of the contents of fspec into its work buffer,
+ * then returns a pointer into somewhere inside the work buffer that is the
+ * start of the serialized output.
+ * Returns NULL on failure, which shouldn't happen */
+static const char *serialize(format *fspec) {
+  const char hex_lower[16] = "0123456789abcdef";
+  /* This alphabet works for decimal, octal, and uppercase hex */
+  const char hex_upper[16] = "0123456789ABCDEF";
+  const char *alphabet = hex_upper;
+
+  uint64_t arg;
+  int mask_step;
+  switch (fspec->fmt) {
+    case 's':
+      return fspec->arg.strarg;
+    case 'c':
+      fspec->work[0] = fspec->arg.charg;
+      fspec->work[1] = 0;
+      return fspec->work;
+    case 'x':
+      alphabet = hex_lower;
+    case 'p':
+    case 'X':
+      mask_step = 16;
+      arg = fspec->arg.uarg;
+      break;
+    case 'o':
+      mask_step = 8;
+      arg = fspec->arg.uarg;
+      break;
+    case 'u':
+      mask_step = 10;
+      arg = fspec->arg.uarg;
+      break;
+    case 'd':
+    case 'i':
+      mask_step = 10;
+      if (fspec->arg.sarg < 0) {
+        arg = (uint64_t)(-fspec->arg.sarg);
+      } else {
+        arg = (uint64_t)fspec->arg.sarg;
+      }
+      break;
+    default:
+      panic("Unexpected format specified found after parsing format string!");
+  }
+
+  int index = sizeof(fspec->work) - 1;
+  fspec->work[index] = 0;
+  do {
+    index--;
+    fspec->work[index] = alphabet[(arg % mask_step)];
+    arg = arg / mask_step;
+  } while (arg > 0);
+
+  return fspec->work + index;
+}
+
+int printf (const char *fmt, ...) {
+  va_list argp;
+  va_start(argp, fmt);
+  int ret = 0;
+  int i = 0;
+
+  while (fmt[i]) {
+    char c = fmt[i++];
+    if (c != '%') {
+      emit(c);
+      continue;
+    }
+
+    format fspec;
+    i += parse_fmt_string(fmt + i, &fspec);
+    if (!fmt[i])  return ret;
+
+    if (fspec.fmt == '%') {
+      my_putch(c);
+      ret++;
+      continue;
+    }
+
+    read_arg(&fspec, argp);
+    const char *buffer = serialize(&fspec);
+
+    uint64_t len = strlen(buffer);
+    char padchar = ' ';
+    if ((fspec.flags & FLAGS_ZERO_PAD) && !(c == 's' || c == 'c')) {
+      padchar = '0';
+    }
+    if (fspec.prefix) {
+      len += strlen(fspec.prefix);
+      /* For zero-padding the prefix goes before padding; otherwise after. */
+      if (padchar == '0') {
+        emits(fspec.prefix);
+      }
+    }
+    if (!(fspec.flags & FLAGS_LEFT_JUST)) {
+      for (uint64_t j = len; j < fspec.min_width; ++j) {
+        emit(padchar);
+      }
+    }
+    if (fspec.prefix && padchar == ' ') {
+      emits(fspec.prefix);
+    }
+    for (uint64_t j = 0; buffer[j]; ++j) {
+      emit(buffer[j]);
+    }
+    if (fspec.flags & FLAGS_LEFT_JUST) {
+      for (uint64_t j = len; j < fspec.min_width; ++j) {
+        emit(' ');
+      }
+    }
+  }
+  return ret;
+}
+

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -175,8 +175,8 @@ static const char *serialize(format *fspec) {
       fspec->work[1] = 0;
       return fspec->work;
     case 'x':
-      alphabet = hex_lower;
     case 'p':
+      alphabet = hex_lower;
     case 'X':
       mask_step = 16;
       arg = fspec->arg.uarg;
@@ -199,7 +199,7 @@ static const char *serialize(format *fspec) {
       }
       break;
     default:
-      panic("Unexpected format specified found after parsing format string!");
+      panic("Unexpected format specifier found after parsing format string!");
   }
 
   int index = sizeof(fspec->work) - 1;
@@ -213,7 +213,7 @@ static const char *serialize(format *fspec) {
   return fspec->work + index;
 }
 
-int vprintf (void (*my_putch)(char), const char *fmt, va_list argp) {
+int kvprintf (void (*my_putch)(char), const char *fmt, va_list argp) {
   int ret = 0;
   int i = 0;
 

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -1,13 +1,12 @@
 #include "printf.h"
 
-#include "com.h"
 #include "util.h"
 
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#define emit(c) do { com_putch(c); ++ret; } while(0)
+#define emit(c) do { my_putch(c); ++ret; } while(0)
 #define emits(s) do { const char *_c = (s); \
                       while (*_c) { emit(*(_c++)); } } while(0)
 
@@ -214,9 +213,7 @@ static const char *serialize(format *fspec) {
   return fspec->work + index;
 }
 
-int printf (const char *fmt, ...) {
-  va_list argp;
-  va_start(argp, fmt);
+int vprintf (void (*my_putch)(char), const char *fmt, va_list argp) {
   int ret = 0;
   int i = 0;
 

--- a/kernel/printf.h
+++ b/kernel/printf.h
@@ -4,7 +4,7 @@
 #include <stdarg.h>
 
 /* We support the following standard printf format specifiers:
- * %[optional flags][optional pad width][xXodiupsc%][optional length h/l]
+ * %[optional flags][optional pad width][optional length h/l][xXodiupsc%]
  * Default lengths are assumed to be 32 bits wide. Note in particular the lack
  * of floating-point support and therefore the length specifier L. We also do
  * not support precision modifiers. */

--- a/kernel/printf.h
+++ b/kernel/printf.h
@@ -1,0 +1,6 @@
+#ifndef __SILVOS_PRINTF_H
+#define __SILVOS_PRINTF_H
+
+int printf (const char *fmt, ...);
+
+#endif

--- a/kernel/printf.h
+++ b/kernel/printf.h
@@ -1,6 +1,13 @@
 #ifndef __SILVOS_PRINTF_H
 #define __SILVOS_PRINTF_H
 
-int printf (const char *fmt, ...);
+#include <stdarg.h>
+
+/* We support the following standard printf format specifiers:
+ * %[optional flags][optional pad width][xXodiupsc%][optional length h/l]
+ * Default lengths are assumed to be 32 bits wide. Note in particular the lack
+ * of floating-point support and therefore the length specifier L. We also do
+ * not support precision modifiers. */
+int vprintf (void (*my_putch)(char), const char *fmt, va_list argp);
 
 #endif

--- a/kernel/printf.h
+++ b/kernel/printf.h
@@ -8,6 +8,6 @@
  * Default lengths are assumed to be 32 bits wide. Note in particular the lack
  * of floating-point support and therefore the length specifier L. We also do
  * not support precision modifiers. */
-int vprintf (void (*my_putch)(char), const char *fmt, va_list argp);
+int kvprintf (void (*my_putch)(char), const char *fmt, va_list argp);
 
 #endif

--- a/kernel/util.c
+++ b/kernel/util.c
@@ -31,6 +31,12 @@ int strncmp (const char *a, const char *b, size_t n) {
   return 0;
 }
 
+uint64_t strlen (const char *s) {
+  uint64_t i = 0;
+  while (s[i]) i++;
+  return i;
+}
+
 void __attribute__ ((noreturn)) qemu_debug_shutdown (void) {
   /* This works, as long as you include the following argument to QEMU:
    *    -device isa-debug-exit,iobase=0xf4,iosize=0x04

--- a/kernel/util.h
+++ b/kernel/util.h
@@ -22,11 +22,14 @@ static inline void bit_array_set(bit_array a, uint64_t i, int b) {
   }
 }
 
-
+#ifdef UNIT_TEST
+#include <string.h>
+#else
 void memset (void *ptr, char byte, size_t count);
 void memcpy (void *dest, const void *src, size_t count);
 int strncmp (const char *s1, const char *s2, size_t n);
 size_t strlen (const char *s);
+#endif
 void __attribute__ ((noreturn)) qemu_debug_shutdown (void);
 void __attribute__ ((noreturn)) panic (const char *s);
 void blab (void);

--- a/kernel/util.h
+++ b/kernel/util.h
@@ -26,6 +26,7 @@ static inline void bit_array_set(bit_array a, uint64_t i, int b) {
 void memset (void *ptr, char byte, size_t count);
 void memcpy (void *dest, const void *src, size_t count);
 int strncmp (const char *s1, const char *s2, size_t n);
+size_t strlen (const char *s);
 void __attribute__ ((noreturn)) qemu_debug_shutdown (void);
 void __attribute__ ((noreturn)) panic (const char *s);
 void blab (void);

--- a/kernel/vga.c
+++ b/kernel/vga.c
@@ -1,5 +1,8 @@
 #include "vga.h"
 
+#include "printf.h"
+
+#include <stdarg.h>
 #include <stdint.h>
 
 #define VGA 0xFFFFFF80000B8000
@@ -60,27 +63,11 @@ void puts (const char *s) {
   }
 }
 
-void puti (uint32_t i) {
-  char d = i % 10 + '0';
-  uint32_t rest = i / 10;
-  if (rest) {
-    puti(rest);
-  }
-  putc(d);
-}
-
-void put_byte (uint8_t d) {
-  const char *out = "0123456789ABCDEF";
-  putc(out[0x0F & (d >> 4)]);
-  putc(out[0x0F & (d)]);
-}
-
-void put_short (uint16_t d) {
-  put_byte((uint8_t)(d >> 8));
-  put_byte((uint8_t)(d));
-}
-
-void put_int (uint32_t d) {
-  put_short((uint16_t)(d >> 16));
-  put_short((uint16_t)(d));
+int vga_printf (const char *fmt, ...) {
+  int ret;
+  va_list argp;
+  va_start(argp, fmt);
+  ret = kvprintf(putc, fmt, argp);
+  va_end(argp);
+  return ret;
 }

--- a/kernel/vga.h
+++ b/kernel/vga.h
@@ -4,12 +4,10 @@
 #include <stdint.h>
 
 void putc (char c);
+void puts (const char *c);
 void clear_screen (void);
-void puts (const char *s);
-void puti (uint32_t i);
 
-void put_byte (uint8_t d);
-void put_short (uint16_t d);
-void put_int (uint32_t d);
+/* Make sure to put a \r\n at the end of your vga_printfs! */
+int vga_printf (const char *fmt, ...);
 
 #endif

--- a/tests/printf/expected.txt
+++ b/tests/printf/expected.txt
@@ -1,0 +1,32 @@
+Hello, World!
+Ed balls
+The magic number is 42
+100% chance of failure
+Some longs: 1099511627776 -1099511627776
+I speak hex: 0x42 0x1234567890abcdef
+I CAN SHOUT: 0xAAAA 0xA1AEA1AEA1AE
+0777 is the best permission
+Number of times I've printfed a short: 1
+|          short|
+|loooooooooooooooooooooooooooooong|
+|              1|
+|              0|
+|             10|
+|            +10|
+|             -1|
+|000000000000010|
+|+00000000000010|
+|-00000000000042|
+| 00000000000010|
+|     0xdeadbeef|
+|short          |
+|1              |
+|0              |
+|10             |
+|+10            |
+|-1             |
+|10             |
+|+10            |
+|-42            |
+| 10            |
+|0xdeadbeef     |

--- a/tests/printf/main.c
+++ b/tests/printf/main.c
@@ -1,0 +1,85 @@
+#include "printf.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void __attribute__ ((noreturn)) panic (const char *s) {
+  printf("Panic! %s\n", s);
+  exit(-1);
+}
+
+static char my_output[1000];
+static int my_ix;
+void putch2(char c) {
+  putchar(c);
+  my_output[my_ix++] = c;
+}
+
+void test_vprintf(const char *fmt, ...) {
+  int my_ret;
+  my_ix = 0;
+  {
+    va_list argp;
+    va_start(argp, fmt);
+    my_ret = kvprintf(putch2, fmt, argp);
+    va_end(argp);
+  }
+  int their_ret;
+  char their_output[1000];
+  {
+    va_list argp;
+    va_start(argp, fmt);
+    their_ret = vsprintf(their_output, fmt, argp);
+    va_end(argp);
+  }
+  if (my_ret != their_ret) {
+    printf("Error on %s: %d != %d\n", fmt, my_ret, their_ret);
+  }
+  my_output[my_ix] = 0;
+  int res = strcmp(my_output, their_output);
+  if (res != 0) {
+    printf("Error on %s: %s != %s\n", fmt, my_output, their_output);
+  }
+}
+
+int main() {
+  /* Basic formatting */
+  test_vprintf("Hello, %s!\n", "World");
+  test_vprintf("Ed ball%c\n", 's');
+  test_vprintf("The magic number is %d\n", 42);
+  test_vprintf("%u%% chance of failure\n", 100u);
+  test_vprintf("Some longs: %lu %ld\n", 1099511627776lu, -1099511627776l);
+  test_vprintf("I speak hex: 0x%x 0x%lx\n", 0x42, 0x1234567890abcdefl);
+  test_vprintf("I CAN SHOUT: 0x%X 0x%lX\n", 0xaaaa, 0xa1aea1aea1ael);
+  test_vprintf("0%o is the best permission\n", 0777);
+  test_vprintf("Number of times I've printfed a short: %hi\n", (short)1);
+
+  /* Padding (subtle.) */
+  test_vprintf("|%15s|\n", "short");
+  test_vprintf("|%15s|\n", "loooooooooooooooooooooooooooooong");
+  test_vprintf("|%15d|\n", 1);
+  test_vprintf("|%15d|\n", 0);
+  test_vprintf("|%15d|\n", 10);
+  test_vprintf("|%+15d|\n", 10);
+  test_vprintf("|%15d|\n", -1);
+  test_vprintf("|%015d|\n", 10);
+  test_vprintf("|%+015d|\n", 10);
+  test_vprintf("|%015d|\n", -42);
+  test_vprintf("|% 015d|\n", 10);
+  test_vprintf("|%15p|\n", 0xdeadbeef);
+
+  /* And left-justified... */
+  test_vprintf("|%-15s|\n", "short");
+  test_vprintf("|%-15d|\n", 1);
+  test_vprintf("|%-15d|\n", 0);
+  test_vprintf("|%-15d|\n", 10);
+  test_vprintf("|%-+15d|\n", 10);
+  test_vprintf("|%-15d|\n", -1);
+
+  /* The zero-filling doesn't have an effect here. */
+  test_vprintf("|%-015d|\n", 10);
+  test_vprintf("|%-+015d|\n", 10);
+  test_vprintf("|%-015d|\n", -42);
+  test_vprintf("|%- 015d|\n", 10);
+  test_vprintf("|%-15p|\n", 0xdeadbeef);
+}

--- a/userland/test-memory/expected.txt
+++ b/userland/test-memory/expected.txt
@@ -11,6 +11,6 @@ THREAD 0x02: Freeing
 THREAD 0x01: Reading
 THREAD 0x02: Reading
 THREAD 0x01: Page faulting
-Kernel: THREAD 0x01 page fault at 0x0000000000004000
+Kernel page fault at 0x4000, running thread is 0x01.
 THREAD 0x02: Page faulting
-Kernel: THREAD 0x02 page fault at 0x0000000000004000
+Kernel page fault at 0x4000, running thread is 0x02.


### PR DESCRIPTION
Also stop pagefault-looping if we get a pagefault *before* running_tcb is set to a sane value.