### PR TITLE
Print a PCI device map on startup

### DIFF
--- a/kernel/acpi.c
+++ b/kernel/acpi.c
@@ -38,17 +38,16 @@ int acpi_parse_rsdp (void) {
 }
 
 int acpi_parse_table (struct ACPISDTHeader *table) {
+  puts("ACPI ");
   for (int i = 0; i < 4; i++) {
     putc(table->Signature[i]);
   }
+  putc(' ');
   if (acpi_checksum((uint8_t *)table, table->Length)) {
-    putc('\r');
-    putc('\n');
+    puts("Invalid Checksum!\r\n");
     return -1; /* Bad checksum */
   }
-  putc('!');
-  putc('\r');
-  putc('\n');
+  puts("Init\r\n");
   if (!strncmp(table->Signature, "RSDT", 4)) {
     rsdt = (struct RSDT *)table;
     uint32_t num_entries = (rsdt->h.Length - sizeof(rsdt->h)) / 4;

--- a/kernel/ide.c
+++ b/kernel/ide.c
@@ -16,7 +16,6 @@ prdt_entry *prdt;
 uint8_t *ide_buf;
 
 void ide_device_register (uint8_t bus, uint8_t device, uint8_t function) {
-  puts("Found IDE device.\r\n");
   /* For now, assume that these are all ports.  If the low bit is not set, then
    * they are actually memory addresses. */
   bar0 = pci_read(4, function, device, bus) & 0xFFFC;
@@ -36,56 +35,29 @@ void ide_device_register (uint8_t bus, uint8_t device, uint8_t function) {
   if (bar3 == 0x00) {
     bar3 = IDE_DEFAULT_BAR0;
   }
-  put_int(bar0);
-  puts("\r\n");
-  put_int(bar1);
-  puts("\r\n");
-  put_int(bar2);
-  puts("\r\n");
-  put_int(bar3);
-  puts("\r\n");
-  put_int(bar4);
-  puts("\r\n");
-  puts("\r\n\r\n");
   outb(bar0 + ATA_REG_HDDEVSEL, 0xA0);
   inb(bar0 + 0x07);
   inb(bar0 + 0x07);
   inb(bar0 + 0x07);
   inb(bar0 + 0x07);
-  put_byte(inb(bar0 + 0x07));
-  puts(" ");
-  put_short(inw(bar0));
-  puts("\r\n");
 
   outb(bar0 + ATA_REG_HDDEVSEL, 0xB0);
   inb(bar0 + 0x07);
   inb(bar0 + 0x07);
   inb(bar0 + 0x07);
   inb(bar0 + 0x07);
-  put_byte(inb(bar0 + 0x07));
-  puts(" ");
-  put_short(inw(bar0));
-  puts("\r\n");
 
   outb(bar2 + ATA_REG_HDDEVSEL, 0xA0);
   inb(bar2 + 0x07);
   inb(bar2 + 0x07);
   inb(bar2 + 0x07);
   inb(bar2 + 0x07);
-  put_byte(inb(bar2 + 0x07));
-  puts(" ");
-  put_short(inw(bar0));
-  puts("\r\n");
 
   outb(bar2 + ATA_REG_HDDEVSEL, 0xB0);
   inb(bar2 + 0x07);
   inb(bar2 + 0x07);
   inb(bar2 + 0x07);
   inb(bar2 + 0x07);
-  put_byte(inb(bar2 + 0x07));
-  puts(" ");
-  put_short(inw(bar0));
-  puts("\r\n");
 
   prdt = (prdt_entry *)allocate_phys_page();
   ide_buf = (uint8_t *)allocate_phys_page();

--- a/kernel/pci.c
+++ b/kernel/pci.c
@@ -13,7 +13,12 @@ typedef struct pci_handler_s {
 } pci_handler;
 
 static pci_handler pci_handlers[] = {
-  { PCI_CLASS_IDE_CONTROLLER, ide_device_register, "IDE Controller"},
+  { PCI_CLASS_IDE_CONTROLLER, ide_device_register, "IDE Controller" },
+  { PCI_CLASS_HOST_BRIDGE, NULL, "Host Bridge" },
+  { PCI_CLASS_ISA_BRIDGE, NULL, "ISA Bridge" },
+  { PCI_CLASS_OTHER_BRIDGE, NULL, "Other Bridge" },
+  { PCI_CLASS_VGA_CONTROLLER, NULL, "VGA Controller" },
+  { PCI_CLASS_ETHERNET_CONTROLLER, NULL, "Ethernet Controller" },
   { 0, NULL, NULL },
 };
 
@@ -40,6 +45,9 @@ void initialize_device (uint8_t bus, uint8_t device, uint8_t function, uint16_t 
     }
   }
   puts(name);
+  if (initializer == NULL) {
+    puts(" (Unhandled)");
+  }
   puts("\r\n");
   if (initializer != NULL) {
     initializer(bus, device, function);

--- a/kernel/pci.h
+++ b/kernel/pci.h
@@ -15,6 +15,11 @@
 #define PCI_VENDOR_INVALID 0xFFFF
 
 #define PCI_CLASS_IDE_CONTROLLER 0x0101
+#define PCI_CLASS_HOST_BRIDGE 0x0600
+#define PCI_CLASS_ISA_BRIDGE 0x0601
+#define PCI_CLASS_OTHER_BRIDGE 0x0680
+#define PCI_CLASS_VGA_CONTROLLER 0x0300
+#define PCI_CLASS_ETHERNET_CONTROLLER 0x0200
 
 static inline void pci_set_addr (uint8_t register_num,
                                  uint8_t function_num,


### PR DESCRIPTION
Also some minor other boot message changes.

I didn't take the time to look at the information that ide.c was printing out but it looks useless and messes up the PCI device map.