### PR TITLE
Test user mode optimization settings in all_opts.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,18 @@ KERNEL_OPT += -g
 #KERNEL_OPT += -flto
 endif
 
+ifeq ($(origin USER_OPT), undefined)
+USER_OPT := -O2
+endif
+
 KERN_CFLAGS := -ffreestanding -mno-red-zone -Wall -Wextra -std=c99 -mno-mmx -mno-sse -mno-sse2 -mcmodel=kernel $(KERNEL_OPT)
 KERN_LDFLAGS := -nostdlib -lgcc -Wl,-z,max-page-size=0x1000 -mcmodel=kernel -mno-mmx -mno-sse -mno-sse2 $(KERNEL_OPT)
 
 BOOTLOADER_CFLAGS := -ffreestanding -mno-red-zone -Wall -Wextra -std=c99 -O2 -g
 BOOTLOADER_LDFLAGS := -nostdlib -Wl,--no-warn-mismatch -Wl,-z,max-page-size=0x1000
 
-USER_CFLAGS := -ffreestanding -Wall -Wextra -Wno-main -std=c99 -O2
-USER_LDFLAGS := -nostdlib -lgcc
+USER_CFLAGS := -ffreestanding -Wall -Wextra -Wno-main -std=c99 $(USER_OPT)
+USER_LDFLAGS := -nostdlib -lgcc $(USER_OPT)
 
 CC := x86_64-elf-gcc
 AS := x86_64-elf-as

--- a/script/all_opts.sh
+++ b/script/all_opts.sh
@@ -2,8 +2,11 @@
 
 set -eu
 
-for oflag in -O0 -O1 -O2 -O3 -Os; do
+for oflag in -O0 -O2 -O3 -Os; do
   for ltoflag in -flto ''; do
-    KERNEL_OPT="$oflag -g $ltoflag " make clean test
+    for uoflag in -O0 -O2; do
+      make clean
+      USER_OPT="$uoflag" KERNEL_OPT="$oflag -g $ltoflag " make -j $(nproc) test
+     done
   done
 done

--- a/script/all_opts.sh
+++ b/script/all_opts.sh
@@ -2,11 +2,9 @@
 
 set -eu
 
-for oflag in -O0 -O2 -O3 -Os; do
-  for ltoflag in -flto ''; do
-    for uoflag in -O0 -O2; do
-      make clean
-      USER_OPT="$uoflag" KERNEL_OPT="$oflag -g $ltoflag " make -j $(nproc) test
-     done
-  done
+for oflag in '-O0' '-O2' '-O3' '-O3 -flto'; do
+  for uoflag in -O0 -O2; do
+    make clean
+    USER_OPT="$uoflag" KERNEL_OPT="$oflag -g" make -j $(nproc) test
+   done
 done

--- a/userland/test-fork/main.c
+++ b/userland/test-fork/main.c
@@ -9,6 +9,8 @@ int test_fork() {
     DEBUG("Fork failed!");
     exit();
   } else if (ret == 0) {
+    /* Temporary fix to flakiness in this test */
+    nanosleep(1000);
     ++depth;
     char child_msg[] = "Child, depth 0";
     child_msg[sizeof(child_msg)-2] = '0' + depth;

--- a/userland/test-memory/main.c
+++ b/userland/test-memory/main.c
@@ -1,11 +1,11 @@
 #include "userland.h"
 #define DEBUG(str) debug(str, sizeof(str))
 
-inline unsigned char* getpage(unsigned int i) {
+static inline unsigned char* getpage(unsigned int i) {
   return (unsigned char*) ((1 << i) * 4096L);
 }
 
-inline unsigned char getent(unsigned int i, unsigned int j, int pid) {
+static inline unsigned char getent(unsigned int i, unsigned int j, int pid) {
   return ((i * 37) ^ j ^ pid) & 0xff;
 }
 


### PR DESCRIPTION
Reduce the number of kernel mode optimizations that are test in all_opts.sh, temporary fix for race condition in test-fork #46, and fix -O0 compilation of test-memory.