### PR TITLE
Simplify PCI device location, and prettify output.

### DIFF
--- a/kernel/pci.c
+++ b/kernel/pci.c
@@ -12,17 +12,28 @@ typedef struct pci_handler_s {
   const char *name;
 } pci_handler;
 
+/* List of known class/subclasses, and how to handle them.  At some point this
+ * information may not be specific enough to determine how to use a given
+ * device, but it's okay for now. */
 static pci_handler pci_handlers[] = {
   { PCI_CLASS_IDE_CONTROLLER, ide_device_register, "IDE Controller" },
+  { PCI_CLASS_ETHERNET_CONTROLLER, NULL, "Ethernet Controller" },
+  { PCI_CLASS_VGA_CONTROLLER, NULL, "VGA Controller" },
+  { PCI_CLASS_AUDIO_CONTROLLER, NULL, "Audio Controller" },
   { PCI_CLASS_HOST_BRIDGE, NULL, "Host Bridge" },
   { PCI_CLASS_ISA_BRIDGE, NULL, "ISA Bridge" },
   { PCI_CLASS_OTHER_BRIDGE, NULL, "Other Bridge" },
-  { PCI_CLASS_VGA_CONTROLLER, NULL, "VGA Controller" },
-  { PCI_CLASS_ETHERNET_CONTROLLER, NULL, "Ethernet Controller" },
   { 0, NULL, NULL },
 };
 
-void initialize_device (uint8_t bus, uint8_t device, uint8_t function, uint16_t vendor) {
+/* Returns non-zero if the function exists. */
+uint8_t initialize_function (uint8_t bus, uint8_t device, uint8_t function) {
+  uint32_t vendor_product = pci_read(0, function, device, bus);
+  uint16_t vendor = vendor_product;
+  uint16_t product = vendor_product >> 16;
+  if (vendor == PCI_VENDOR_INVALID) {
+    return 0;
+  }
   uint16_t class_subclass = pci_read(2, function, device, bus) >> 16;
   const char *name = "Unknown";
   pci_device_init initializer = NULL;
@@ -33,38 +44,35 @@ void initialize_device (uint8_t bus, uint8_t device, uint8_t function, uint16_t 
       break;
     }
   }
-  vga_printf("PCI %02x:%02x.%02x (class: %04hx vendor: %04hx) %s%s\r\n",
-             bus, device, function, class_subclass, vendor,
-             name, initializer == NULL ? " (Unhandled)" : "");
+  vga_printf("PCI %02x:%02x.%01x  [%04hx] %-20s  [%04hx:%04hx] %s\r\n",
+             bus, device, function, class_subclass, name, vendor,
+             product, initializer == NULL ? " (Unhandled)" : "");
   if (initializer != NULL) {
     initializer(bus, device, function);
   }
+  return 1;
 }
 
-void check_device (uint8_t bus, uint8_t device) {
-  uint8_t function = 0;
-  uint16_t vendor = pci_read(0, function, device, bus) & 0xFFFF;
-  if (vendor == PCI_VENDOR_INVALID) {
+void initialize_device (uint8_t bus, uint8_t device) {
+  if (!initialize_function(bus, device, 0)) {
     return;
   }
-  initialize_device(bus, device, function, vendor);
-  uint8_t header_type = (pci_read(3, function, device, bus) >> 16) & 0xFF;
-  if (0x80 & header_type) {
-    /* Multi-function device */
-    for (function = 1; function < PCI_NUM_FUNCTION; function++) {
-      uint16_t vendor = pci_read(0, function, device, bus) & 0xFFFF;
-      if (vendor == PCI_VENDOR_INVALID) {
-        continue;
-      }
-      initialize_device(bus, device, function, vendor);
-    }
+  /* If this is a single-function device, then only look at function 0.  Some
+   * single-function devices report the same device on every function, rather
+   * than only reporting it on 0. */
+  uint8_t header_type = pci_read(3, 0, device, bus) >> 16;
+  if (!(header_type & 0x80)) {
+    return;
+  }
+  for (uint8_t fn = 1; fn < PCI_NUM_FUNCTION; fn++) {
+    initialize_function(bus, device, fn);
   }
 }
 
 void check_all_pci_busses (void) {
   for (unsigned int bus = 0; bus < PCI_NUM_BUS; bus++) {
     for (unsigned int dev = 0; dev < PCI_NUM_DEV; dev++) {
-      check_device(bus, dev);
+      initialize_device(bus, dev);
     }
   }
 }

--- a/kernel/pci.h
+++ b/kernel/pci.h
@@ -14,12 +14,13 @@
 
 #define PCI_VENDOR_INVALID 0xFFFF
 
-#define PCI_CLASS_IDE_CONTROLLER 0x0101
-#define PCI_CLASS_HOST_BRIDGE 0x0600
-#define PCI_CLASS_ISA_BRIDGE 0x0601
-#define PCI_CLASS_OTHER_BRIDGE 0x0680
-#define PCI_CLASS_VGA_CONTROLLER 0x0300
+#define PCI_CLASS_IDE_CONTROLLER      0x0101
 #define PCI_CLASS_ETHERNET_CONTROLLER 0x0200
+#define PCI_CLASS_VGA_CONTROLLER      0x0300
+#define PCI_CLASS_AUDIO_CONTROLLER    0x0401
+#define PCI_CLASS_HOST_BRIDGE         0x0600
+#define PCI_CLASS_ISA_BRIDGE          0x0601
+#define PCI_CLASS_OTHER_BRIDGE        0x0680
 
 static inline void pci_set_addr (uint8_t register_num,
                                  uint8_t function_num,


### PR DESCRIPTION
There's only 8 functions per device, so there's not much point in skipping the
missing 7 functions when we're still probing every single PCI bus.

Add a little bit more information to what's printed out; the [nnnn:nnnn] syntax
is borrowed from lspci.