### PR TITLE
Enable unwinding through pf_isr

### DIFF
--- a/kernel/isr-asm.s
+++ b/kernel/isr-asm.s
@@ -144,3 +144,70 @@ pf_isr:
 	call pagefault_handler
 	pop_caller_save_reg
 	iretq
+end_pf_isr:
+
+
+/* Unwind information for pf_isr */
+    .section .eh_frame
+    .align 8
+cie_start:
+    .long cie_end - cie_start - 0x04 /* length of CIE */
+    .long 0x00000000  /* CIE 'magic' */
+    .byte 0x01        /* CIE version */
+    .byte 'z'         /* Augmentation data = zR\0 */
+    .byte 'R'
+    .byte 0x00
+    .byte 0x01        /* Code alignment = 1 */
+    .word 0x1078      /* Data alignment = -8 */
+    .byte 0x01        /* Augmentation data length */
+    .byte 0x1b        /* Pointer encoding: relative, signed 32 */
+    .byte 0x0c        /* Start of initial instructions: Define CFA [...] */
+    .word 0x0807      /* [...] CFA = r7 (rsp) + 8 */
+    .word 0x0190      /* r16 (rip) = CFA + 1 * (-8) */
+    .align 8
+cie_end:
+    .long end_eh_frame - . - 0x04
+    .long . - cie_start /* CIE pointer */
+    .reloc ., R_X86_64_PC32, .text + (pf_isr - .text)
+    .long 0x00000000    /* filled by reloc */
+    .long end_pf_isr - pf_isr
+    .byte 0x00          /* Aug data */
+    .word 0x200e        /* CFA = rsp+32 */
+    .word 0x0390        /* rip @ CFA-24 */
+    .byte 0x41          /* advance 1 */
+    .word 0x280e        /* CFA = rsp+40 */
+    .byte 0x41          /* [...] */
+    .word 0x300e
+    .byte 0x41
+    .word 0x380e
+    .byte 0x41
+    .word 0x400e
+    .byte 0x41
+    .word 0x480e
+    .byte 0x42          /* Some pushes are 2 bytes */
+    .word 0x500e
+    .byte 0x42
+    .word 0x580e
+    .byte 0x42
+    .word 0x600e
+    .byte 0x42
+    .word 0x680e        /* CFA = rsp+104 */
+    .byte 0x4a          /* advance 10 (past 'call') */
+    .word 0x600e        /* CFA = rsp+96 */
+    .byte 0x42          /* advance 2 */
+    .word 0x580e        /* [...] */
+    .byte 0x42
+    .word 0x500e
+    .byte 0x42
+    .word 0x480e
+    .byte 0x41
+    .word 0x400e
+    .byte 0x41
+    .word 0x380e
+    .byte 0x41
+    .word 0x300e
+    .byte 0x41
+    .word 0x280e
+    .byte 0x41
+    .align 8
+end_eh_frame:

--- a/kernel/unwind.c
+++ b/kernel/unwind.c
@@ -505,7 +505,7 @@ static int find_fde(uint64_t rip, eh_cie* cie_out, eh_fde* fde_out) {
     memset(&fde, 0, sizeof(eh_fde));
     fde.cie = &current_cie;
     if (read_fde(&subhead, &fde)) { return -1; }
-    if (rip >= fde.pc_begin && rip - fde.pc_begin < fde.pc_len) {
+    if (rip >= fde.pc_begin && rip - fde.pc_begin <= fde.pc_len) {
       *cie_out = current_cie;
       fde.cie = cie_out;
       *fde_out = fde;
@@ -546,7 +546,7 @@ void gen_backtrace(uint64_t rsp, uint64_t rip, uint64_t rbp) {
 
     int ret = find_fde(rip, &cie, &fde);
     if (ret == 1) {
-      com_printf("(Top of stack frame)\n");
+      com_printf("(Top-of-stack frame)\n");
       return;
     } else if (ret) {
       com_printf("Error encountered! Sorry.\n");


### PR DESCRIPTION
Add eh_frame DWARF operations compiled by hand to handle the wonky
stack frame pushed before pf_isr happens.