### PR TITLE
Fix Dockerfile to build on BUILD and run tests on RUN.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
 FROM cstanfill/silvos:latest
 
 COPY . /root/silvos
+
+WORKDIR /root/silvos
+
+RUN make
+
+CMD make test


### PR DESCRIPTION
This dockerfile was useless before.


Now it makes the kernel when you build the dockerfile and it runs the tests when you run the container.