### PR TITLE
Refactor synchronous IPC

### DIFF
--- a/kernel/ipc.c
+++ b/kernel/ipc.c
@@ -11,40 +11,55 @@ typedef struct {
   unsigned long long r2;
 } ipc_msg;
 
-void __attribute__((noreturn)) sendrecv (void) {
-  ipc_msg send;
-  send.addr = running_tcb->saved_registers.rbx;
-  send.r1 = running_tcb->saved_registers.rcx;
-  send.r2 = running_tcb->saved_registers.rdx;
-  uint64_t sender = running_tcb->thread_id;
+static inline ipc_msg get_msg (void) {
+  ipc_msg send = {
+    .addr = running_tcb->saved_registers.rbx,
+    .r1 = running_tcb->saved_registers.rcx,
+    .r2 = running_tcb->saved_registers.rdx,
+  };
+  return send;
+}
 
-  /* Throughout this function, use chained if-else rather than guard clauses to
-   * statically verify that every branch ends in an __attribute__((noreturn))
-   * function */
-  if (send.addr == sender) {
+static void __attribute__((noreturn)) do_send (ipc_msg send, tcb *recv_tcb) {
+  recv_tcb->ipc_state = IPC_NOT_RECEIVING;
+  recv_tcb->saved_registers.rax = MESSAGE_RECEIVED;
+  recv_tcb->saved_registers.rbx = running_tcb->thread_id;
+  recv_tcb->saved_registers.rcx = send.r1;
+  recv_tcb->saved_registers.rdx = send.r2;
+  switch_thread_to(recv_tcb);
+}
+
+void __attribute__((noreturn)) call (void) {
+  ipc_msg send = get_msg();
+  tcb* recv_thread = get_tcb(send.addr);
+
+  if (recv_thread == 0 ||
+      recv_thread == running_tcb ||
+      recv_thread->ipc_state != IPC_DAEMON) {
     running_tcb->saved_registers.rax = SEND_FAILED;
     return_to_current_thread();
-  } else if (send.addr == 0) {
-    /* Message to kernel */
-    running_tcb->ipc_state = IPC_RECEIVING;
-    schedule();
-  } else {
-    tcb* recv_thread = get_tcb(send.addr);
-
-    if (!recv_thread) {
-      running_tcb->saved_registers.rax = SEND_FAILED;
-      return_to_current_thread();
-    } else if (recv_thread->ipc_state != IPC_RECEIVING) {
-      running_tcb->saved_registers.rax = SEND_FAILED;
-      return_to_current_thread();
-    } else {
-      recv_thread->ipc_state = IPC_NOT_RECEIVING;
-      recv_thread->saved_registers.rax = MESSAGE_RECEIVED;
-      recv_thread->saved_registers.rbx = sender;
-      recv_thread->saved_registers.rcx = send.r1;
-      recv_thread->saved_registers.rdx = send.r2;
-      running_tcb->ipc_state = IPC_RECEIVING;
-      switch_thread_to(recv_thread);
-    }
   }
+
+  running_tcb->ipc_state = IPC_CALLING;
+  running_tcb->callee = send.addr;
+  do_send(send, recv_thread);
+}
+
+void __attribute__((noreturn)) respond (void) {
+  ipc_msg resp = get_msg();
+  tcb* recv_thread = get_tcb(resp.addr);
+
+  if (resp.addr == 0) {
+    /* Request to daemonize. */
+    running_tcb->ipc_state = IPC_DAEMON;
+    schedule();
+  } else if (recv_thread == 0 ||
+             recv_thread->ipc_state != IPC_CALLING ||
+             recv_thread->callee != running_tcb->thread_id) {
+    running_tcb->saved_registers.rax = SEND_FAILED;
+    return_to_current_thread();
+  }
+
+  running_tcb->ipc_state = IPC_DAEMON;
+  do_send(resp, recv_thread);
 }

--- a/kernel/ipc.h
+++ b/kernel/ipc.h
@@ -1,9 +1,6 @@
 #ifndef __SILVOS_IPC_H
 #define __SILVOS_IPC_H
 
-#include "syscall-defs.h"
-
 void __attribute__((noreturn)) sendrecv (void);
-void sendrecv_finish (void);
 
 #endif

--- a/kernel/ipc.h
+++ b/kernel/ipc.h
@@ -1,6 +1,7 @@
 #ifndef __SILVOS_IPC_H
 #define __SILVOS_IPC_H
 
-void __attribute__((noreturn)) sendrecv (void);
+void __attribute__((noreturn)) call (void);
+void __attribute__((noreturn)) respond (void);
 
 #endif

--- a/kernel/isr-asm.s
+++ b/kernel/isr-asm.s
@@ -47,7 +47,7 @@
 
 /* Syscalls */
 
-/* The syscall ABI is:
+/* The syscall ABI for syscalls other than sendrecv() is:
  *
  *  REG | INPUT | OUTPUT
  *  --------------------
@@ -56,6 +56,19 @@
  *  RCX | ARG2  | PRESERVED
  *
  * All other registers are unused and preserved.
+ *
+ * For sendrecv() it is instead:
+ *
+ *  REG | INPUT | OUTPUT
+ *  --------------------
+ *  RAX | SYSNO | RETURN (status)
+ *  RBX | ADDR  | RETURN
+ *  RCX | ARG1  | RETURN
+ *  RDX | ARG2  | RETURN
+ *
+ * All other registers are still unused and preserved.
+ * The RETURN register meanings correspond to the inputs, eg
+ * RBX is the address that a message came from.
  */
 
 .GLOBAL syscall_isr

--- a/kernel/syscall-defs.h
+++ b/kernel/syscall-defs.h
@@ -3,21 +3,9 @@
 
 typedef unsigned long long syscall_arg;
 
-typedef struct {
-  unsigned long addr;
-  unsigned long r1;
-  unsigned long r2;
-} ipc_msg;
-
-typedef struct {
-  ipc_msg send; /* Filled in by the user */
-  ipc_msg recv; /* Filled in by the kernel on a receive */
-} sendrecv_op;
-
 typedef enum {
   MESSAGE_RECEIVED = 0,
   SEND_FAILED = 1,
-  RECEIVE_FAILED = 2,
 } sendrecv_status;
 
 #define SYSCALL_YIELD       0x00

--- a/kernel/syscall-defs.h
+++ b/kernel/syscall-defs.h
@@ -20,8 +20,9 @@ typedef enum {
 #define SYSCALL_NANOSLEEP   0x09
 #define SYSCALL_FORK        0x0A
 #define SYSCALL_SPAWN       0x0B
-#define SYSCALL_SENDRECV    0x0C
+#define SYSCALL_CALL        0x0C
+#define SYSCALL_RESPOND     0x0D
 
-#define NUM_SYSCALLS        0x0D
+#define NUM_SYSCALLS        0x0E
 
 #endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -65,7 +65,8 @@ syscall_func syscall_defns[NUM_SYSCALLS] = {
   hpet_nanosleep,
   TRAMPOLINE_NAME(fork),
   TRAMPOLINE_NAME(spawn_within_vm_space),
-  sendrecv,
+  call,
+  respond,
 };
 
 void __attribute__((noreturn)) syscall_handler (void) {

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -121,7 +121,6 @@ static void __attribute__((noreturn)) return_to_userspace (void) {
      * fault occurs, it will bring is back to the normal kernel stack location.
      */
     hpet_reset_timeout();
-    sendrecv_finish();
     enter_userspace(&running_tcb->saved_registers);
   } else {
     /* We have to be careful returning to the idle thread.  Because the idle

--- a/kernel/threads.c
+++ b/kernel/threads.c
@@ -156,10 +156,7 @@ void __attribute__((noreturn)) schedule (void) {
   for (int i = 0; i < NUMTHREADS; ++i) {
     tcb* thread = &tcbs[i];
     if (thread->state == TS_NONEXIST) continue;
-    /* Threads that are in IPC_RECEIVING are considered dormant.
-     * If a thread is in sendrecv() but is about to wake up with a message,
-     * that's different and is indicated by IPC_RECEIVED */
-    if (thread->ipc_state == IPC_RECEIVING) continue;
+    if (thread->ipc_state == IPC_DAEMON) continue;
     ++num_threads;
   }
   if (num_threads == 0) {

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -1,9 +1,9 @@
 #ifndef __SILVOS_THREADS_H
 #define __SILVOS_THREADS_H
 
-#include "ipc.h"
 #include "list.h"
 #include "page.h"
+#include "syscall-defs.h"
 
 #include <stdint.h>
 #include <stddef.h>
@@ -25,7 +25,6 @@ enum fpu_state {
 enum ipc_state {
   IPC_NOT_RECEIVING,
   IPC_RECEIVING,      /* currently waiting for an ipc message */
-  IPC_RECEIVED,       /* in the middle of receiving an ipc handoff */
 };
 
 typedef struct {
@@ -79,7 +78,6 @@ typedef struct {
   enum fpu_state fpu_state;
   char (*fpu_buf)[512];
   enum ipc_state ipc_state;
-  ipc_msg inbox;  /* Only valid if ipc_state is RECEIVED */
 } tcb;
 
 /* Pointer to the TCB of the running userspace thread, or NULL if currently

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -24,7 +24,8 @@ enum fpu_state {
 
 enum ipc_state {
   IPC_NOT_RECEIVING,
-  IPC_RECEIVING,      /* currently waiting for an ipc message */
+  IPC_CALLING,        /* currently waiting for a response */
+  IPC_DAEMON,         /* currently waiting for a call */
 };
 
 typedef struct {
@@ -78,6 +79,7 @@ typedef struct {
   enum fpu_state fpu_state;
   char (*fpu_buf)[512];
   enum ipc_state ipc_state;
+  uint8_t callee;  /* Only valid if IPC_CALLING */
 } tcb;
 
 /* Pointer to the TCB of the running userspace thread, or NULL if currently

--- a/userland/test-ipc/main.c
+++ b/userland/test-ipc/main.c
@@ -5,44 +5,36 @@
 void vasily() {
   sendrecv_op op;
   op.send.addr = 0;
+  op.send.r1 = 0;
+  op.send.r2 = 0;
   while (1) {
-    switch (sendrecv(&op)) {
-      case SEND_FAILED:
-        DEBUG("SEND FAILED");
-        return;
-      case RECEIVE_FAILED:
-        DEBUG("RECEIVE FAILED");
-        return;
-      case MESSAGE_RECEIVED:
-        DEBUG("RECEIVED");
-        op.send.addr = op.recv.addr;
-        op.send.r1 = op.recv.r1 + op.recv.r2;
-        op.send.r2 = op.recv.r1 - op.recv.r2;
-        break;
+    if (sendrecv(&op)) {
+      DEBUG("SEND FAILED");
+      return;
     }
+    DEBUG("RECEIVED");
+    op.send.addr = op.recv.addr;
+    op.send.r1 = op.recv.r1 + op.recv.r2;
+    op.send.r2 = op.recv.r1 - op.recv.r2;
   }
 }
 
 void fedia(int addr) {
   sendrecv_op op;
   op.send.addr = addr;
+  op.send.r1 = 0;
+  op.send.r2 = 0;
   for (unsigned long long i = 1; i <= 10; ++i) {
     op.send.r1 = i;
     op.send.r2 = 5;
-    switch (sendrecv(&op)) {
-      case SEND_FAILED:
-        DEBUG("SEND_FAILED");
-        return;
-      case RECEIVE_FAILED:
-        DEBUG("RECEIVE FAILED");
-        return;
-      case MESSAGE_RECEIVED:
-        if (op.recv.r1 + op.recv.r2 == i * 2 && op.recv.r1 - op.recv.r2 == 10) {
-          DEBUG("GOT RIGHT ANSWER");
-        } else {
-          DEBUG("GOT WRONG ANSWER!!");
-        }
-        break;
+    if (sendrecv(&op)) {
+      DEBUG("SEND FAILED");
+      return;
+    }
+    if (op.recv.r1 + op.recv.r2 == i * 2 && op.recv.r1 - op.recv.r2 == 10) {
+      DEBUG("GOT RIGHT ANSWER");
+    } else {
+      DEBUG("GOT WRONG ANSWER!!");
     }
   }
 }

--- a/userland/test-ipc/main.c
+++ b/userland/test-ipc/main.c
@@ -8,7 +8,7 @@ void vasily() {
   op.send.r1 = 0;
   op.send.r2 = 0;
   while (1) {
-    if (sendrecv(&op)) {
+    if (respond(&op)) {
       DEBUG("SEND FAILED");
       return;
     }
@@ -27,7 +27,7 @@ void fedia(int addr) {
   for (unsigned long long i = 1; i <= 10; ++i) {
     op.send.r1 = i;
     op.send.r2 = 5;
-    if (sendrecv(&op)) {
+    if (call(&op)) {
       DEBUG("SEND FAILED");
       return;
     }

--- a/userland/userland.h
+++ b/userland/userland.h
@@ -88,15 +88,23 @@ static inline void spawn_thread (const void *code, void *stack) {
   __syscall2(SYSCALL_SPAWN, (syscall_arg)code, (syscall_arg)stack);
 }
 
-static inline sendrecv_status sendrecv (sendrecv_op *op) {
+static inline sendrecv_status __ipc (unsigned long syscallno, sendrecv_op *op) {
   sendrecv_status status;
   ipc_msg msg = op->send;
   __asm__ volatile("int $0x36"
                    : "=a" (status), "+b" (msg.addr), "+c" (msg.r1), "+d" (msg.r2)
-                   : "a" (SYSCALL_SENDRECV)
+                   : "a" (syscallno)
                    : "memory");
   op->recv = msg;
   return status;
+}
+
+static inline sendrecv_status call (sendrecv_op *op) {
+  return __ipc(SYSCALL_CALL, op);
+}
+
+static inline sendrecv_status respond (sendrecv_op *op) {
+  return __ipc(SYSCALL_RESPOND, op);
 }
 
 #endif


### PR DESCRIPTION
This lets us simplify a lot:
- Get rid of the RECEIVED_FAILED error code
- Stop doing copy_to_user in the IPC code
- Remove the sendrecv-specific thread-switch hook
- Remove the IPC_RECEIVED thread state and thread inboxes

Also cleaned up some documentation and the inline asm in the userland header to match the documented ABI.