### PR TITLE
Add fork_daemon (analogous to spawn_daemon)

### DIFF
--- a/kernel/isr-asm.s
+++ b/kernel/isr-asm.s
@@ -118,7 +118,7 @@
  *
  * All other registers are unused and preserved.
  *
- * For sendrecv() it is instead:
+ * For call(), respond(), and fork_daemon() it is instead:
  *
  *  REG | INPUT | OUTPUT
  *  --------------------
@@ -127,9 +127,12 @@
  *  RCX | ARG1  | RETURN
  *  RDX | ARG2  | RETURN
  *
- * All other registers are still unused and preserved.
- * The RETURN register meanings correspond to the inputs, eg
- * RBX is the address that a message came from.
+ * (For fork_daemon in particular, 'ADDR' is ignored.  The same return ABI is
+ * used in the old thread and in the new thread.)
+ *
+ * All other registers are still unused and preserved.  The RETURN register
+ * meanings correspond to the inputs, eg RBX is the address that a message came
+ * from.
  */
 
 .GLOBAL syscall_isr

--- a/kernel/syscall-defs.h
+++ b/kernel/syscall-defs.h
@@ -33,7 +33,9 @@ typedef unsigned long long semaphore_id;
 #define SYSCALL_FIND_PROC   0x14
 #define SYSCALL_SPAWN_DAEMON 0x15
 #define SYSCALL_SET_HANDLER 0x16
+#define SYSCALL_GET_TID     0x17
+#define SYSCALL_FORK_DAEMON 0x18
 
-#define NUM_SYSCALLS        0x17
+#define NUM_SYSCALLS        0x19
 
 #endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -54,6 +54,7 @@ TRAMPOLINE1(sem_unwatch)
 TRAMPOLINE1(sem_set)
 TRAMPOLINE1(find_module)
 TRAMPOLINE1(set_handler)
+TRAMPOLINE0(get_tid)
 
 #pragma GCC diagnostic pop
 
@@ -83,6 +84,8 @@ syscall_func syscall_defns[NUM_SYSCALLS] = {
   TRAMPOLINE_NAME(find_module),
   spawn_daemon_within_vm_space,
   TRAMPOLINE_NAME(set_handler),
+  TRAMPOLINE_NAME(get_tid),
+  fork_daemon,
 };
 
 void __attribute__((noreturn)) syscall_handler (void) {

--- a/kernel/threads.h
+++ b/kernel/threads.h
@@ -143,6 +143,13 @@ void __attribute__((noreturn)) thread_exit_fault (void);
  * new thread ID in the parent, and to 0 in the child. */
 int fork (void);
 
+/* Combination of 'fork' and 'call/respond'.  Takes in a message (similar to
+ * call/respond, but with no dest addr.)  Puts the parent in a CALLing state,
+ * and returns that message in the child.  (Because it was the message just
+ * sent, the child can figure out that they are the child.)  When the child
+ * responds, the parent will wake up again with the child's message. */
+void __attribute__((noreturn)) fork_daemon (void);
+
 /* Make a new thread in the current VM space, starting at the given %rip with
  * the given %rsp.  All other registers are zero. */
 int spawn_within_vm_space (uint64_t rip, uint64_t rsp);
@@ -157,5 +164,8 @@ int set_handler (int);
 /* Get the TCB struct for the thread with the given thread ID;  returns NULL if
  * that thread does not exist. */
 tcb *get_tcb (uint64_t tid);
+
+/* Get thread ID of running thread. */
+int get_tid (void);
 
 #endif

--- a/userland/userland.h
+++ b/userland/userland.h
@@ -107,6 +107,10 @@ static inline sendrecv_status respond (sendrecv_op *op) {
   return __ipc(SYSCALL_RESPOND, op);
 }
 
+static inline sendrecv_status fork_daemon (sendrecv_op *op) {
+  return __ipc(SYSCALL_FORK_DAEMON, op);
+}
+
 static inline semaphore_id sem_create() {
   return __syscall0(SYSCALL_SEM_CREATE);
 }
@@ -141,6 +145,10 @@ static inline int spawn_daemon (const void *code, void *stack) {
 
 static inline int set_handler (int handler_tid) {
   return __syscall1(SYSCALL_SET_HANDLER, (syscall_arg)handler_tid);
+}
+
+static inline int get_tid (void) {
+  return (int)__syscall0(SYSCALL_GET_TID);
 }
 
 #endif


### PR DESCRIPTION
In this case there's a very nice IPC-based API that can be used.  When you call
fork_daemon, you pass in a message (just like for call/respond).  The
destination field is ignored; instead, a new thread is created via fork, and
put into the DAEMON state, and the message is sent to that thread.  The parent
is put into the CALLING state.  So, when the child responds, the parent will
wake up.

This is only really usable if you can figure out your own thread-id, so add a
syscall for that too.